### PR TITLE
feat: discover/weather/onboarding bundle + UI polish

### DIFF
--- a/lib/data/local/local_repository.dart
+++ b/lib/data/local/local_repository.dart
@@ -3,7 +3,8 @@ import 'package:guachinches/data/local/restaurant_sql_lite.dart';
 
 abstract class LocalRepository{
   Future<bool> insertRestaurant(String restaurantId);
-  Future<RestaurantSQLLite> getRestaurant(String restaurantId);
+  Future<RestaurantSQLLite?> getRestaurant(String restaurantId);
+  Future<bool> isFavorite(String restaurantId);
   Future<bool> removeRestaurant(String restaurantId);
   Future<List<RestaurantSQLLite>> getRestaurants();
 }

--- a/lib/data/local/restaurant_sql_lite.dart
+++ b/lib/data/local/restaurant_sql_lite.dart
@@ -9,8 +9,9 @@ class RestaurantSQLLite {
   }
 
   RestaurantSQLLite.fromMap(Map<String, dynamic> mapa) {
-    _id = mapa["id"] as String;
-    _restaurantId = mapa["restaurantId"] as String;
+    final rawId = mapa["Id"] ?? mapa["id"];
+    _id = rawId?.toString() ?? '';
+    _restaurantId = (mapa["restaurantId"] ?? '').toString();
   }
 
   @override

--- a/lib/data/local/sql_lite_local_repository.dart
+++ b/lib/data/local/sql_lite_local_repository.dart
@@ -4,42 +4,45 @@ import 'package:guachinches/data/local/restaurant_sql_lite.dart';
 import 'local_repository.dart';
 
 class SqlLiteLocalRepository implements LocalRepository {
-
-
   @override
   Future<List<RestaurantSQLLite>> getRestaurants() async {
     final db = await DBProvider.db.database;
-    var res = await db.rawQuery("select * from fav");
-    List<RestaurantSQLLite> restaurants = [];
-    if(res.isNotEmpty){
-      res.forEach((element) {
-        RestaurantSQLLite restaurantSQLLite = RestaurantSQLLite.fromMap(element);
-        restaurants.add(restaurantSQLLite);
-      });
-      return restaurants;
-    }else{
-      return [];
-    }
+    final res = await db.rawQuery("SELECT * FROM fav");
+    if (res.isEmpty) return [];
+    return res.map(RestaurantSQLLite.fromMap).toList();
   }
 
   @override
-  Future<RestaurantSQLLite> getRestaurant(String restaurantId) async {
+  Future<RestaurantSQLLite?> getRestaurant(String restaurantId) async {
     final db = await DBProvider.db.database;
-    String query = "select * from fav where restaurantId='" + restaurantId + "'";
-    var res = await db.rawQuery(query);
-    if(res.isEmpty) {
-      return RestaurantSQLLite.fromMap({});
-    } else return RestaurantSQLLite.fromMap(res[0]);
+    final res = await db.rawQuery(
+      "SELECT * FROM fav WHERE restaurantId = ? LIMIT 1",
+      [restaurantId],
+    );
+    if (res.isEmpty) return null;
+    return RestaurantSQLLite.fromMap(res.first);
+  }
+
+  @override
+  Future<bool> isFavorite(String restaurantId) async {
+    final db = await DBProvider.db.database;
+    final res = await db.rawQuery(
+      "SELECT 1 FROM fav WHERE restaurantId = ? LIMIT 1",
+      [restaurantId],
+    );
+    return res.isNotEmpty;
   }
 
   @override
   Future<bool> insertRestaurant(String restaurantId) async {
     try {
       final db = await DBProvider.db.database;
-      var res = await db.rawInsert("INSERT Into fav (restaurantId)"
-          " VALUES ('" + restaurantId + "')");
+      await db.rawInsert(
+        "INSERT INTO fav (restaurantId) VALUES (?)",
+        [restaurantId],
+      );
       return true;
-    } on Exception catch (e) {
+    } catch (_) {
       return false;
     }
   }
@@ -48,10 +51,13 @@ class SqlLiteLocalRepository implements LocalRepository {
   Future<bool> removeRestaurant(String restaurantId) async {
     try {
       final db = await DBProvider.db.database;
-      var res = await db.rawInsert("DELETE FROM fav where restaurantId='" + restaurantId + "'");
-      return false;
-    } on Exception catch (e) {
+      await db.rawDelete(
+        "DELETE FROM fav WHERE restaurantId = ?",
+        [restaurantId],
+      );
       return true;
+    } catch (_) {
+      return false;
     }
   }
 }

--- a/lib/data/services/weather_service.dart
+++ b/lib/data/services/weather_service.dart
@@ -1,0 +1,166 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Condición meteorológica simplificada que usa la UI para decidir
+/// qué overlays renderizar (nubes/lluvia/etc.).
+enum WeatherCondition {
+  unknown,
+  clear,         // soleado / despejado
+  mostlyClear,   // mayormente despejado
+  partlyCloudy,  // parcialmente nuboso
+  cloudy,        // nublado / cubierto
+  fog,
+  drizzle,
+  rain,
+  heavyRain,
+  thunderstorm,
+  snow,
+}
+
+extension WeatherConditionVisuals on WeatherCondition {
+  bool get hasClouds => switch (this) {
+        WeatherCondition.mostlyClear ||
+        WeatherCondition.partlyCloudy ||
+        WeatherCondition.cloudy ||
+        WeatherCondition.fog ||
+        WeatherCondition.drizzle ||
+        WeatherCondition.rain ||
+        WeatherCondition.heavyRain ||
+        WeatherCondition.thunderstorm ||
+        WeatherCondition.snow =>
+          true,
+        _ => false,
+      };
+
+  /// Densidad relativa de nubes (0..1).
+  double get cloudIntensity => switch (this) {
+        WeatherCondition.mostlyClear => 0.15,
+        WeatherCondition.partlyCloudy => 0.25,
+        WeatherCondition.cloudy => 0.40,
+        WeatherCondition.fog => 0.50,
+        WeatherCondition.drizzle => 0.32,
+        WeatherCondition.rain => 0.40,
+        WeatherCondition.heavyRain => 0.50,
+        WeatherCondition.thunderstorm => 0.55,
+        WeatherCondition.snow => 0.38,
+        _ => 0.0,
+      };
+
+  bool get hasRain => switch (this) {
+        WeatherCondition.drizzle ||
+        WeatherCondition.rain ||
+        WeatherCondition.heavyRain ||
+        WeatherCondition.thunderstorm =>
+          true,
+        _ => false,
+      };
+
+  /// Cantidad de gotas en pantalla (densidad).
+  int get rainDensity => switch (this) {
+        WeatherCondition.drizzle => 30,
+        WeatherCondition.rain => 80,
+        WeatherCondition.heavyRain => 140,
+        WeatherCondition.thunderstorm => 180,
+        _ => 0,
+      };
+
+  double get rainTilt => switch (this) {
+        WeatherCondition.thunderstorm => 0.30,
+        WeatherCondition.heavyRain => 0.24,
+        _ => 0.16,
+      };
+}
+
+/// Wrapper sobre Open-Meteo (gratis, sin API key) que devuelve la condición
+/// meteorológica actual para una coordenada. Cachea la última respuesta
+/// durante 15 minutos para evitar llamadas repetidas en hot reloads.
+class WeatherService {
+  WeatherService._();
+  static final WeatherService instance = WeatherService._();
+
+  final Map<String, _CacheEntry> _cache = {};
+  static const Duration _ttl = Duration(minutes: 15);
+
+  Future<WeatherCondition> currentCondition({
+    required double lat,
+    required double lon,
+  }) async {
+    final key = '${lat.toStringAsFixed(2)},${lon.toStringAsFixed(2)}';
+    final cached = _cache[key];
+    if (cached != null && DateTime.now().difference(cached.at) < _ttl) {
+      return cached.condition;
+    }
+
+    final uri = Uri.parse(
+      'https://api.open-meteo.com/v1/forecast'
+      '?latitude=$lat&longitude=$lon&current=weather_code'
+      '&timezone=auto',
+    );
+    try {
+      final res = await http.get(uri).timeout(const Duration(seconds: 5));
+      if (res.statusCode != 200) return WeatherCondition.unknown;
+      final body = json.decode(res.body) as Map<String, dynamic>;
+      final code = (body['current'] as Map<String, dynamic>?)?['weather_code'];
+      if (code is! num) return WeatherCondition.unknown;
+      final condition = _mapCode(code.toInt());
+      _cache[key] = _CacheEntry(condition, DateTime.now());
+      return condition;
+    } catch (_) {
+      return WeatherCondition.unknown;
+    }
+  }
+
+  /// WMO weather codes → simplified enum.
+  /// Ref: https://open-meteo.com/en/docs (sección "weather_code").
+  static WeatherCondition _mapCode(int code) {
+    switch (code) {
+      case 0:
+        return WeatherCondition.clear;
+      case 1:
+        return WeatherCondition.mostlyClear;
+      case 2:
+        return WeatherCondition.partlyCloudy;
+      case 3:
+        return WeatherCondition.cloudy;
+      case 45:
+      case 48:
+        return WeatherCondition.fog;
+      case 51:
+      case 53:
+      case 55:
+      case 56:
+      case 57:
+        return WeatherCondition.drizzle;
+      case 61:
+      case 63:
+      case 80:
+      case 81:
+        return WeatherCondition.rain;
+      case 65:
+      case 66:
+      case 67:
+      case 82:
+        return WeatherCondition.heavyRain;
+      case 71:
+      case 73:
+      case 75:
+      case 77:
+      case 85:
+      case 86:
+        return WeatherCondition.snow;
+      case 95:
+      case 96:
+      case 99:
+        return WeatherCondition.thunderstorm;
+      default:
+        return WeatherCondition.unknown;
+    }
+  }
+}
+
+class _CacheEntry {
+  final WeatherCondition condition;
+  final DateTime at;
+  const _CacheEntry(this.condition, this.at);
+}

--- a/lib/ui/components/clouds_overlay.dart
+++ b/lib/ui/components/clouds_overlay.dart
@@ -1,0 +1,185 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Overlay decorativo de nubes blancas que se desplazan lentamente.
+/// Pensado para ponerse dentro de un `Stack` que cubra solo la zona del
+/// hero — recorta los hijos con `ClipRect` para que no se asomen.
+class CloudsOverlay extends StatefulWidget {
+  final int count;
+  final double opacity;
+  final Duration baseDuration;
+
+  const CloudsOverlay({
+    super.key,
+    this.count = 4,
+    this.opacity = 0.55,
+    this.baseDuration = const Duration(seconds: 60),
+  });
+
+  @override
+  State<CloudsOverlay> createState() => _CloudsOverlayState();
+}
+
+class _CloudsOverlayState extends State<CloudsOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final List<_Cloud> _clouds;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(vsync: this, duration: widget.baseDuration)
+      ..repeat();
+    final rng = math.Random(42);
+    _clouds = List.generate(widget.count, (i) {
+      return _Cloud(
+        yFrac: 0.05 + rng.nextDouble() * 0.55,
+        scale: 0.6 + rng.nextDouble() * 0.9,
+        speed: 0.55 + rng.nextDouble() * 0.55,
+        offsetFrac: rng.nextDouble(),
+        opacity: 0.55 + rng.nextDouble() * 0.45,
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRect(
+      child: LayoutBuilder(
+        builder: (_, c) {
+          final w = c.maxWidth;
+          final h = c.maxHeight;
+          return AnimatedBuilder(
+            animation: _ctrl,
+            builder: (_, __) {
+              return Stack(
+                children: [
+                  for (final cloud in _clouds)
+                    _CloudView(
+                      cloud: cloud,
+                      width: w,
+                      height: h,
+                      progress: _ctrl.value,
+                      baseOpacity: widget.opacity,
+                    ),
+                ],
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _Cloud {
+  final double yFrac;
+  final double scale;
+  final double speed;
+  final double offsetFrac;
+  final double opacity;
+  const _Cloud({
+    required this.yFrac,
+    required this.scale,
+    required this.speed,
+    required this.offsetFrac,
+    required this.opacity,
+  });
+}
+
+class _CloudView extends StatelessWidget {
+  final _Cloud cloud;
+  final double width;
+  final double height;
+  final double progress;
+  final double baseOpacity;
+
+  const _CloudView({
+    required this.cloud,
+    required this.width,
+    required this.height,
+    required this.progress,
+    required this.baseOpacity,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cloudWidth = 180 * cloud.scale;
+    final cloudHeight = 70 * cloud.scale;
+    // Phase wraps from 0 to 1; cloud drifts right→left across the viewport.
+    final t = (progress * cloud.speed + cloud.offsetFrac) % 1.0;
+    final dx = width - (width + cloudWidth) * t;
+    final dy = cloud.yFrac * (height - cloudHeight);
+    return Positioned(
+      left: dx,
+      top: dy,
+      child: IgnorePointer(
+        child: Opacity(
+          opacity: (baseOpacity * cloud.opacity).clamp(0.0, 1.0),
+          child: SizedBox(
+            width: cloudWidth,
+            height: cloudHeight,
+            child: const RepaintBoundary(child: _CloudPainter()),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CloudPainter extends StatelessWidget {
+  const _CloudPainter();
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(painter: _CloudShape());
+  }
+}
+
+class _CloudShape extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final w = size.width;
+    final h = size.height;
+
+    // Three layered passes with decreasing blur produce a soft, painterly
+    // cloud rather than hard-edged circles.
+    final passes = <Paint>[
+      Paint()
+        ..color = Colors.white.withOpacity(0.55)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 22),
+      Paint()
+        ..color = Colors.white.withOpacity(0.75)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 14),
+      Paint()
+        ..color = Colors.white.withOpacity(0.92)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 7),
+    ];
+
+    void puff(Offset c, double r, Paint p) => canvas.drawCircle(c, r, p);
+
+    for (final p in passes) {
+      puff(Offset(w * 0.22, h * 0.66), h * 0.40, p);
+      puff(Offset(w * 0.40, h * 0.46), h * 0.50, p);
+      puff(Offset(w * 0.58, h * 0.42), h * 0.55, p);
+      puff(Offset(w * 0.78, h * 0.60), h * 0.42, p);
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTWH(w * 0.16, h * 0.62, w * 0.66, h * 0.24),
+          Radius.circular(h * 0.20),
+        ),
+        p,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _CloudShape oldDelegate) => false;
+}

--- a/lib/ui/components/rain_overlay.dart
+++ b/lib/ui/components/rain_overlay.dart
@@ -1,0 +1,144 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Overlay decorativo de lluvia. Pensado para colocarse dentro de un
+/// `Stack` con `Clip.hardEdge` (igual que `CloudsOverlay`) para que los
+/// rayados no se asomen fuera del hero.
+class RainOverlay extends StatefulWidget {
+  /// Cantidad de gotas en pantalla. 80 → lluvia media.
+  final int density;
+  /// Inclinación en radianes (0 = vertical, ~0.25 = ligeramente diagonal).
+  final double tilt;
+  /// Opacidad global.
+  final double opacity;
+  /// Color base (por defecto blanco-azulado, tipo escena de día gris).
+  final Color color;
+
+  const RainOverlay({
+    super.key,
+    this.density = 80,
+    this.tilt = 0.18,
+    this.opacity = 0.55,
+    this.color = const Color(0xFFE6F2FA),
+  });
+
+  @override
+  State<RainOverlay> createState() => _RainOverlayState();
+}
+
+class _RainOverlayState extends State<RainOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final List<_Drop> _drops;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 2),
+    )..repeat();
+    final rng = math.Random(7);
+    _drops = List.generate(widget.density, (i) {
+      return _Drop(
+        xFrac: rng.nextDouble(),
+        offset: rng.nextDouble(),
+        speed: 0.8 + rng.nextDouble() * 0.7,
+        length: 14 + rng.nextDouble() * 16,
+        thickness: 1.0 + rng.nextDouble() * 0.8,
+        opacity: 0.55 + rng.nextDouble() * 0.45,
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRect(
+      child: IgnorePointer(
+        child: RepaintBoundary(
+          child: AnimatedBuilder(
+            animation: _ctrl,
+            builder: (_, __) => CustomPaint(
+              size: Size.infinite,
+              painter: _RainPainter(
+                drops: _drops,
+                progress: _ctrl.value,
+                tilt: widget.tilt,
+                color: widget.color.withOpacity(widget.opacity),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Drop {
+  final double xFrac;
+  final double offset;
+  final double speed;
+  final double length;
+  final double thickness;
+  final double opacity;
+  const _Drop({
+    required this.xFrac,
+    required this.offset,
+    required this.speed,
+    required this.length,
+    required this.thickness,
+    required this.opacity,
+  });
+}
+
+class _RainPainter extends CustomPainter {
+  final List<_Drop> drops;
+  final double progress;
+  final double tilt;
+  final Color color;
+
+  _RainPainter({
+    required this.drops,
+    required this.progress,
+    required this.tilt,
+    required this.color,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final w = size.width;
+    final h = size.height;
+    // Travel distance per cycle: a bit more than viewport so drops loop
+    // smoothly off-screen.
+    final travel = h + 80;
+    final dxPerY = math.tan(tilt);
+
+    final paint = Paint()
+      ..strokeCap = StrokeCap.round
+      ..isAntiAlias = true;
+
+    for (final d in drops) {
+      final t = (progress * d.speed + d.offset) % 1.0;
+      final yTop = -40 + travel * t;
+      final yBottom = yTop + d.length;
+      final xTop = d.xFrac * w + dxPerY * yTop;
+      final xBottom = xTop + dxPerY * d.length;
+      paint
+        ..color = color.withOpacity(
+            color.opacity * d.opacity.clamp(0.0, 1.0))
+        ..strokeWidth = d.thickness;
+      canvas.drawLine(Offset(xTop, yTop), Offset(xBottom, yBottom), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _RainPainter old) =>
+      old.progress != progress;
+}

--- a/lib/ui/components/weather_layer.dart
+++ b/lib/ui/components/weather_layer.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:guachinches/data/cubit/location/location_cubit.dart';
+import 'package:guachinches/data/cubit/location/location_state.dart';
+import 'package:guachinches/data/services/weather_service.dart';
+import 'package:guachinches/ui/components/clouds_overlay.dart';
+import 'package:guachinches/ui/components/rain_overlay.dart';
+
+/// Layer meteorológico: consulta el tiempo actual con Open-Meteo y compone
+/// nubes/lluvia/etc. encima del hero. Pensado para colocarse dentro de un
+/// `Stack` con `Clip.hardEdge`.
+///
+/// Si no se pasa `lat`/`lon` explícito, usa la posición del `LocationCubit`
+/// global y, en su defecto, Santa Cruz de Tenerife.
+class WeatherLayer extends StatefulWidget {
+  final double? lat;
+  final double? lon;
+
+  const WeatherLayer({super.key, this.lat, this.lon});
+
+  @override
+  State<WeatherLayer> createState() => _WeatherLayerState();
+}
+
+class _WeatherLayerState extends State<WeatherLayer> {
+  WeatherCondition _condition = WeatherCondition.unknown;
+  bool _fetching = false;
+
+  // Fallback: centro de Tenerife si no hay GPS y no se pasa explícito.
+  static const double _fallbackLat = 28.4682;
+  static const double _fallbackLon = -16.2546;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _fetch());
+  }
+
+  (double, double) _resolveCoords() {
+    if (widget.lat != null && widget.lon != null) {
+      return (widget.lat!, widget.lon!);
+    }
+    final s = context.read<LocationCubit>().state;
+    if (s is LocationLoaded) return (s.latitude, s.longitude);
+    return (_fallbackLat, _fallbackLon);
+  }
+
+  Future<void> _fetch() async {
+    if (_fetching) return;
+    _fetching = true;
+    final (lat, lon) = _resolveCoords();
+    final cond = await WeatherService.instance
+        .currentCondition(lat: lat, lon: lon);
+    if (!mounted) return;
+    setState(() {
+      _condition = cond;
+      _fetching = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<LocationCubit, LocationState>(
+      listenWhen: (prev, curr) =>
+          curr is LocationLoaded && prev is! LocationLoaded,
+      listener: (_, __) => _fetch(),
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 600),
+        child: _buildOverlay(),
+      ),
+    );
+  }
+
+  Widget _buildOverlay() {
+    if (!_condition.hasClouds && !_condition.hasRain) {
+      return const SizedBox.shrink(key: ValueKey('clear'));
+    }
+    return Stack(
+      key: ValueKey(_condition),
+      children: [
+        if (_condition.hasClouds)
+          Positioned.fill(
+            child: IgnorePointer(
+              child: CloudsOverlay(
+                opacity: _condition.cloudIntensity,
+                count: _condition == WeatherCondition.cloudy ||
+                        _condition == WeatherCondition.heavyRain ||
+                        _condition == WeatherCondition.thunderstorm
+                    ? 6
+                    : 4,
+              ),
+            ),
+          ),
+        if (_condition.hasRain)
+          Positioned.fill(
+            child: IgnorePointer(
+              child: RainOverlay(
+                density: _condition.rainDensity,
+                tilt: _condition.rainTilt,
+                opacity: switch (_condition) {
+                  WeatherCondition.drizzle => 0.20,
+                  WeatherCondition.rain => 0.30,
+                  WeatherCondition.heavyRain => 0.38,
+                  WeatherCondition.thunderstorm => 0.45,
+                  _ => 0.30,
+                },
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/ui/pages/advance_search/advanced_search.dart
+++ b/lib/ui/pages/advance_search/advanced_search.dart
@@ -158,6 +158,24 @@ class _AdvancedSearchState extends State<AdvancedSearch> {
     _runSearch();
   }
 
+  /// Header dinámico: si entras con una categoría/tipo prefiltrado desde
+  /// home, lo muestra como título; si no, "Buscar".
+  String _headerTitle() {
+    if (widget.preSelectedCategories.length == 1) {
+      return widget.preSelectedCategories.first.nombre.toUpperCase();
+    }
+    if (widget.preSelectedCategories.length > 1) {
+      return '${widget.preSelectedCategories.length} CATEGORÍAS';
+    }
+    if (widget.preSelectedTypes.length == 1) {
+      return widget.preSelectedTypes.first.nombre.toUpperCase();
+    }
+    if (widget.preSelectedTypes.length > 1) {
+      return '${widget.preSelectedTypes.length} TIPOS';
+    }
+    return 'BUSCAR';
+  }
+
   void _useRecent(String query) {
     _searchController.text = query;
     _searchController.selection = TextSelection.fromPosition(
@@ -175,7 +193,10 @@ class _AdvancedSearchState extends State<AdvancedSearch> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _Header(onBack: () => Navigator.pop(context)),
+            _Header(
+              title: _headerTitle(),
+              onBack: () => Navigator.pop(context),
+            ),
             const SizedBox(height: 8),
             _SearchRow(
               controller: _searchController,
@@ -220,8 +241,9 @@ class _AdvancedSearchState extends State<AdvancedSearch> {
 }
 
 class _Header extends StatelessWidget {
+  final String title;
   final VoidCallback onBack;
-  const _Header({required this.onBack});
+  const _Header({required this.title, required this.onBack});
 
   @override
   Widget build(BuildContext context) {
@@ -237,9 +259,13 @@ class _Header extends StatelessWidget {
             ),
             onPressed: onBack,
           ),
-          Text(
-            'BUSCAR',
-            style: AppTextStyles.displayHero(size: 26),
+          Expanded(
+            child: Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTextStyles.displayHero(size: 26),
+            ),
           ),
         ],
       ),

--- a/lib/ui/pages/details/details_presenter.dart
+++ b/lib/ui/pages/details/details_presenter.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:guachinches/data/RemoteRepository.dart';
-import 'package:guachinches/data/local/restaurant_sql_lite.dart';
 import 'package:guachinches/data/local/sql_lite_local_repository.dart';
 import 'package:guachinches/data/model/Review.dart';
 import 'package:guachinches/data/model/Video.dart';
@@ -123,28 +122,19 @@ class DetailPresenter {
   }
 
   getIsFav(String restaurantId) async {
-    RestaurantSQLLite restaurantSQLLite =
-        await sqlLiteLocalRepository.getRestaurant(restaurantId);
-    bool correct = false;
-    if (restaurantSQLLite != null) {
-      correct = true;
-    } else {
-      correct = false;
-    }
-    _view.setFav(correct);
+    final isFav = await sqlLiteLocalRepository.isFavorite(restaurantId);
+    _view.setFav(isFav);
   }
 
   saveFavRestaurant(String restaurantId) async {
-    bool correct = false;
-    RestaurantSQLLite restaurantSQLLite =
-        await sqlLiteLocalRepository.getRestaurant(restaurantId);
-    if (restaurantSQLLite != null) {
-      correct = await sqlLiteLocalRepository.removeRestaurant(restaurantId);
+    final wasFav = await sqlLiteLocalRepository.isFavorite(restaurantId);
+    if (wasFav) {
+      final ok = await sqlLiteLocalRepository.removeRestaurant(restaurantId);
+      _view.setFav(ok ? false : true);
     } else {
-      correct = await sqlLiteLocalRepository.insertRestaurant(restaurantId);
+      final ok = await sqlLiteLocalRepository.insertRestaurant(restaurantId);
+      _view.setFav(ok ? true : false);
     }
-    sqlLiteLocalRepository.getRestaurants();
-    _view.setFav(correct);
   }
 }
 

--- a/lib/ui/pages/discover/discover_screen.dart
+++ b/lib/ui/pages/discover/discover_screen.dart
@@ -1,0 +1,850 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/config/brand_colors.dart';
+import 'package:guachinches/data/cubit/new_home/visits_cubit.dart';
+import 'package:guachinches/data/model/Visit.dart';
+import 'package:guachinches/ui/pages/discover/widgets/sort_sheet.dart';
+import 'package:guachinches/ui/pages/discover/widgets/visit_filter_sheet.dart';
+import 'package:guachinches/ui/pages/discover/widgets/visit_list_tile.dart';
+import 'package:guachinches/ui/pages/visit/visit_screen.dart';
+
+/// Catálogo de visitas (Jonay, Joana…). Permite buscar texto libre,
+/// filtrar por creador / sentimiento / zona, y ordenar por fecha,
+/// rating o alfabético. Sustituye al antiguo tab Videos.
+class DiscoverScreen extends StatefulWidget {
+  const DiscoverScreen({super.key});
+
+  @override
+  State<DiscoverScreen> createState() => _DiscoverScreenState();
+}
+
+class _DiscoverScreenState extends State<DiscoverScreen> {
+  final TextEditingController _searchCtrl = TextEditingController();
+  Timer? _searchDebounce;
+  String _searchText = '';
+
+  VisitFilterValues _filters = const VisitFilterValues();
+  VisitSort _sort = VisitSort.newest;
+
+  @override
+  void initState() {
+    super.initState();
+    _bootstrap();
+  }
+
+  void _bootstrap() {
+    final cubit = context.read<VisitsCubit>();
+    if (cubit.state is VisitsInitial || cubit.state is VisitsFailure) {
+      cubit.loadVisits();
+    }
+  }
+
+  @override
+  void dispose() {
+    _searchCtrl.dispose();
+    _searchDebounce?.cancel();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String value) {
+    _searchDebounce?.cancel();
+    _searchDebounce = Timer(const Duration(milliseconds: 220), () {
+      if (!mounted) return;
+      setState(() => _searchText = value.trim());
+    });
+  }
+
+  void _clearSearch() {
+    _searchDebounce?.cancel();
+    _searchCtrl.clear();
+    setState(() => _searchText = '');
+  }
+
+  Future<void> _openFilters(List<Visit> all) async {
+    final creators = _uniqueCreators(all);
+    final zones = _uniqueZones(all);
+    final result = await VisitFilterSheet.show(
+      context: context,
+      initial: _filters,
+      creators: creators,
+      zones: zones,
+    );
+    if (result != null) setState(() => _filters = result);
+  }
+
+  Future<void> _openSort() async {
+    final picked = await VisitSortSheet.show(
+      context: context,
+      current: _sort,
+    );
+    if (picked != null && picked != _sort) {
+      setState(() => _sort = picked);
+    }
+  }
+
+  void _toggleCreator(String c) {
+    final next = Set<String>.from(_filters.creators);
+    next.contains(c) ? next.remove(c) : next.add(c);
+    setState(() => _filters = _filters.copyWith(creators: next));
+  }
+
+  void _clearAllFilters() =>
+      setState(() => _filters = const VisitFilterValues());
+
+  // ── Filtering / sorting ────────────────────────────────────────────────
+  List<String> _uniqueCreators(List<Visit> visits) {
+    final set = <String>{};
+    for (final v in visits) {
+      final c = v.creator?.trim();
+      if (c != null && c.isNotEmpty) set.add(c);
+    }
+    final list = set.toList()..sort();
+    return list;
+  }
+
+  List<String> _uniqueZones(List<Visit> visits) {
+    final set = <String>{};
+    for (final v in visits) {
+      final z = (v.zone?.isNotEmpty == true ? v.zone : v.restaurant?.municipio)
+          ?.trim();
+      if (z != null && z.isNotEmpty) set.add(z);
+    }
+    final list = set.toList()..sort();
+    return list;
+  }
+
+  List<Visit> _applyFilters(List<Visit> source) {
+    final q = _searchText.toLowerCase();
+    final filtered = source.where((v) {
+      // Creator
+      if (_filters.creators.isNotEmpty) {
+        final c = v.creator ?? '';
+        if (!_filters.creators.contains(c)) return false;
+      }
+      // Sentiment
+      if (_filters.sentiments.isNotEmpty) {
+        final s = v.overallSentiment ?? '';
+        if (!_filters.sentiments.contains(s)) return false;
+      }
+      // Zone
+      if (_filters.zones.isNotEmpty) {
+        final z = v.zone?.isNotEmpty == true ? v.zone! : v.restaurant?.municipio ?? '';
+        if (!_filters.zones.contains(z)) return false;
+      }
+      // Has video
+      if (_filters.onlyWithVideo) {
+        final hasVideo = (v.videoUrl?.isNotEmpty == true) ||
+            (v.youtubeVideoId?.isNotEmpty == true);
+        if (!hasVideo) return false;
+      }
+      // Free-text search
+      if (q.isNotEmpty) {
+        final haystack = [
+          v.creator,
+          v.name,
+          v.restaurant?.nombre,
+          v.zone,
+          v.restaurant?.municipio,
+          v.summary,
+          v.extraText,
+          ...v.highlights,
+          ...v.dishes.map((d) => d.name),
+          ...v.quotes.map((qt) => qt.text),
+        ].where((e) => e != null && e.toString().isNotEmpty).join(' ').toLowerCase();
+        if (!haystack.contains(q)) return false;
+      }
+      return true;
+    }).toList();
+    return _applySort(filtered);
+  }
+
+  List<Visit> _applySort(List<Visit> list) {
+    int cmpDates(String? a, String? b, {bool desc = true}) {
+      final da = DateTime.tryParse(a ?? '') ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final db = DateTime.tryParse(b ?? '') ?? DateTime.fromMillisecondsSinceEpoch(0);
+      return desc ? db.compareTo(da) : da.compareTo(db);
+    }
+
+    String _name(Visit v) => (v.name?.isNotEmpty == true
+            ? v.name!
+            : v.restaurant?.nombre ?? '')
+        .toLowerCase();
+
+    switch (_sort) {
+      case VisitSort.newest:
+        list.sort((a, b) => cmpDates(
+              a.publishedAt ?? a.createdAt,
+              b.publishedAt ?? b.createdAt,
+              desc: true,
+            ));
+        break;
+      case VisitSort.oldest:
+        list.sort((a, b) => cmpDates(
+              a.publishedAt ?? a.createdAt,
+              b.publishedAt ?? b.createdAt,
+              desc: false,
+            ));
+        break;
+      case VisitSort.ratingDesc:
+        list.sort((a, b) =>
+            (b.ratingImplicit ?? 0).compareTo(a.ratingImplicit ?? 0));
+        break;
+      case VisitSort.alphaAsc:
+        list.sort((a, b) => _name(a).compareTo(_name(b)));
+        break;
+      case VisitSort.byCreator:
+        list.sort((a, b) {
+          final ca = (a.creator ?? '').toLowerCase();
+          final cb = (b.creator ?? '').toLowerCase();
+          final byCreator = ca.compareTo(cb);
+          if (byCreator != 0) return byCreator;
+          return cmpDates(
+            a.publishedAt ?? a.createdAt,
+            b.publishedAt ?? b.createdAt,
+            desc: true,
+          );
+        });
+        break;
+    }
+    return list;
+  }
+
+  // ── Build ──────────────────────────────────────────────────────────────
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: context.brand.base,
+      body: SafeArea(
+        child: BlocBuilder<VisitsCubit, VisitsState>(
+          builder: (context, state) {
+            final allVisits = state is VisitsLoaded ? state.visits : <Visit>[];
+            final isLoading = state is VisitsLoading;
+            final isFailure = state is VisitsFailure;
+            final filtered = _applyFilters(allVisits);
+            final creators = _uniqueCreators(allVisits);
+
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _DiscoverHeader(
+                  total: filtered.length,
+                  isLoading: isLoading && allVisits.isEmpty,
+                  sortLabel: _sort.label,
+                  filterCount: _filters.count,
+                  onSort: _openSort,
+                  onFilter: () => _openFilters(allVisits),
+                ),
+                const SizedBox(height: 12),
+                _SearchRow(
+                  controller: _searchCtrl,
+                  onChanged: _onSearchChanged,
+                  onClear: _clearSearch,
+                ),
+                const SizedBox(height: 8),
+                _CreatorChipsRow(
+                  creators: creators,
+                  selected: _filters.creators,
+                  onTap: _toggleCreator,
+                  onMore: () => _openFilters(allVisits),
+                ),
+                if (_filters.count > 0)
+                  _ActiveFiltersBar(
+                    filters: _filters,
+                    onRemoveCreator: _toggleCreator,
+                    onRemoveSentiment: (s) {
+                      final next = Set<String>.from(_filters.sentiments)..remove(s);
+                      setState(
+                          () => _filters = _filters.copyWith(sentiments: next));
+                    },
+                    onRemoveZone: (z) {
+                      final next = Set<String>.from(_filters.zones)..remove(z);
+                      setState(
+                          () => _filters = _filters.copyWith(zones: next));
+                    },
+                    onToggleVideo: () => setState(() => _filters =
+                        _filters.copyWith(onlyWithVideo: false)),
+                    onClearAll: _clearAllFilters,
+                  ),
+                const SizedBox(height: 4),
+                Expanded(
+                  child: _buildBody(
+                    state: state,
+                    isLoading: isLoading,
+                    isFailure: isFailure,
+                    filtered: filtered,
+                    hasFilters: _filters.count > 0 || _searchText.isNotEmpty,
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody({
+    required VisitsState state,
+    required bool isLoading,
+    required bool isFailure,
+    required List<Visit> filtered,
+    required bool hasFilters,
+  }) {
+    if (isLoading) {
+      return const Center(
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          color: AppColors.atlanticoClaro,
+        ),
+      );
+    }
+    if (isFailure) {
+      return _ErrorState(
+        onRetry: () => context.read<VisitsCubit>().loadVisits(),
+      );
+    }
+    if (filtered.isEmpty) {
+      return _EmptyState(
+        hasFilters: hasFilters,
+        onClear: () {
+          _clearAllFilters();
+          _clearSearch();
+        },
+      );
+    }
+    return RefreshIndicator(
+      color: AppColors.atlanticoClaro,
+      onRefresh: () async => context.read<VisitsCubit>().loadVisits(),
+      child: ListView.separated(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+        itemCount: filtered.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemBuilder: (_, i) => VisitListTile(
+          visit: filtered[i],
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => VisitDetailPage(visitId: filtered[i].id),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Header ────────────────────────────────────────────────────────────────
+class _DiscoverHeader extends StatelessWidget {
+  final int total;
+  final bool isLoading;
+  final String sortLabel;
+  final int filterCount;
+  final VoidCallback onSort;
+  final VoidCallback onFilter;
+
+  const _DiscoverHeader({
+    required this.total,
+    required this.isLoading,
+    required this.sortLabel,
+    required this.filterCount,
+    required this.onSort,
+    required this.onFilter,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 12, 12, 0),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'VISITAS',
+                  style: AppTextStyles.displayHero(size: 28),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  isLoading
+                      ? 'Cargando…'
+                      : '$total visita${total == 1 ? '' : 's'} · $sortLabel',
+                  style: AppTextStyles.muted(size: 12),
+                ),
+              ],
+            ),
+          ),
+          _IconBubble(icon: Icons.swap_vert_rounded, onTap: onSort),
+          const SizedBox(width: 8),
+          _IconBubble(
+            icon: Icons.tune_rounded,
+            onTap: onFilter,
+            badge: filterCount > 0 ? '$filterCount' : null,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _IconBubble extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback onTap;
+  final String? badge;
+
+  const _IconBubble({
+    required this.icon,
+    required this.onTap,
+    this.badge,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: Container(
+            width: 44,
+            height: 44,
+            decoration: BoxDecoration(
+              color: context.brand.surface,
+              shape: BoxShape.circle,
+              border: Border.all(color: context.brand.border),
+            ),
+            child: Icon(icon, size: 20, color: context.brand.textPrimary),
+          ),
+        ),
+        if (badge != null)
+          Positioned(
+            right: -2,
+            top: -2,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: AppColors.atlantico,
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(color: context.brand.base, width: 2),
+              ),
+              child: Text(
+                badge!,
+                style: AppTextStyles.ui(
+                  size: 10,
+                  weight: FontWeight.w800,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+// ── Search row ────────────────────────────────────────────────────────────
+class _SearchRow extends StatelessWidget {
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onClear;
+
+  const _SearchRow({
+    required this.controller,
+    required this.onChanged,
+    required this.onClear,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Container(
+        height: 48,
+        decoration: BoxDecoration(
+          color: context.brand.surface,
+          border: Border.all(color: context.brand.borderStrong),
+          borderRadius: BorderRadius.circular(100),
+        ),
+        child: Row(
+          children: [
+            const SizedBox(width: 16),
+            Icon(Icons.search_rounded,
+                size: 20, color: AppColors.atlanticoClaro),
+            const SizedBox(width: 10),
+            Expanded(
+              child: TextField(
+                controller: controller,
+                onChanged: onChanged,
+                textInputAction: TextInputAction.search,
+                style: AppTextStyles.ui(
+                  size: 14,
+                  color: context.brand.textPrimary,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'Restaurante, autor, plato…',
+                  hintStyle: AppTextStyles.ui(
+                    size: 14,
+                    color: context.brand.textMuted,
+                  ),
+                  border: InputBorder.none,
+                  isDense: true,
+                ),
+              ),
+            ),
+            ValueListenableBuilder<TextEditingValue>(
+              valueListenable: controller,
+              builder: (_, v, __) {
+                if (v.text.isEmpty) return const SizedBox(width: 12);
+                return GestureDetector(
+                  onTap: onClear,
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 12, left: 4),
+                    child: Container(
+                      width: 22,
+                      height: 22,
+                      decoration: BoxDecoration(
+                        color: context.brand.elevated,
+                        shape: BoxShape.circle,
+                      ),
+                      alignment: Alignment.center,
+                      child: Icon(Icons.close_rounded,
+                          size: 14, color: context.brand.textPrimary),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Creator chips row ─────────────────────────────────────────────────────
+class _CreatorChipsRow extends StatelessWidget {
+  final List<String> creators;
+  final Set<String> selected;
+  final ValueChanged<String> onTap;
+  final VoidCallback onMore;
+
+  const _CreatorChipsRow({
+    required this.creators,
+    required this.selected,
+    required this.onTap,
+    required this.onMore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (creators.isEmpty) return const SizedBox.shrink();
+    return SizedBox(
+      height: 38,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        itemCount: creators.length + 1,
+        separatorBuilder: (_, __) => const SizedBox(width: 8),
+        itemBuilder: (_, i) {
+          if (i == creators.length) {
+            return GestureDetector(
+              onTap: onMore,
+              child: Container(
+                height: 38,
+                padding: const EdgeInsets.symmetric(horizontal: 14),
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: context.brand.surface,
+                  borderRadius: BorderRadius.circular(100),
+                  border: Border.all(color: context.brand.borderStrong),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.tune_rounded,
+                        size: 14, color: context.brand.textPrimary),
+                    const SizedBox(width: 6),
+                    Text(
+                      'Más filtros',
+                      style: AppTextStyles.ui(
+                        size: 12,
+                        weight: FontWeight.w600,
+                        color: context.brand.textPrimary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+          final c = creators[i];
+          final active = selected.contains(c);
+          return GestureDetector(
+            onTap: () => onTap(c),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 160),
+              height: 38,
+              padding: const EdgeInsets.symmetric(horizontal: 14),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: active ? AppColors.atlantico : context.brand.surface,
+                borderRadius: BorderRadius.circular(100),
+                border: Border.all(
+                  color: active
+                      ? AppColors.atlantico
+                      : context.brand.borderStrong,
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.person_rounded,
+                    size: 14,
+                    color: active ? Colors.white : context.brand.textPrimary,
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    c,
+                    style: AppTextStyles.ui(
+                      size: 12,
+                      weight: active ? FontWeight.w700 : FontWeight.w600,
+                      color: active ? Colors.white : context.brand.textPrimary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ── Active filters bar ────────────────────────────────────────────────────
+class _ActiveFiltersBar extends StatelessWidget {
+  final VisitFilterValues filters;
+  final ValueChanged<String> onRemoveCreator;
+  final ValueChanged<String> onRemoveSentiment;
+  final ValueChanged<String> onRemoveZone;
+  final VoidCallback onToggleVideo;
+  final VoidCallback onClearAll;
+
+  const _ActiveFiltersBar({
+    required this.filters,
+    required this.onRemoveCreator,
+    required this.onRemoveSentiment,
+    required this.onRemoveZone,
+    required this.onToggleVideo,
+    required this.onClearAll,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final chips = <Widget>[];
+    for (final c in filters.creators) {
+      chips.add(_RemovableChip(label: c, onRemove: () => onRemoveCreator(c)));
+    }
+    for (final s in filters.sentiments) {
+      chips.add(_RemovableChip(
+        label: kSentimentLabels[s] ?? s,
+        onRemove: () => onRemoveSentiment(s),
+      ));
+    }
+    for (final z in filters.zones) {
+      chips.add(_RemovableChip(label: z, onRemove: () => onRemoveZone(z)));
+    }
+    if (filters.onlyWithVideo) {
+      chips.add(_RemovableChip(label: 'Con vídeo', onRemove: onToggleVideo));
+    }
+    if (chips.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
+      child: SizedBox(
+        height: 36,
+        child: ListView.separated(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          itemCount: chips.length + 1,
+          separatorBuilder: (_, __) => const SizedBox(width: 8),
+          itemBuilder: (_, i) {
+            if (i == chips.length) {
+              return GestureDetector(
+                onTap: onClearAll,
+                child: Container(
+                  height: 36,
+                  alignment: Alignment.center,
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Text(
+                    'Limpiar',
+                    style: AppTextStyles.ui(
+                      size: 12,
+                      weight: FontWeight.w700,
+                      color: AppColors.atlanticoClaro,
+                    ),
+                  ),
+                ),
+              );
+            }
+            return chips[i];
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _RemovableChip extends StatelessWidget {
+  final String label;
+  final VoidCallback onRemove;
+
+  const _RemovableChip({required this.label, required this.onRemove});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onRemove,
+      child: Container(
+        height: 36,
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        decoration: BoxDecoration(
+          color: AppColors.atlantico.withOpacity(0.14),
+          borderRadius: BorderRadius.circular(100),
+          border: Border.all(color: AppColors.atlantico.withOpacity(0.45)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              label,
+              style: AppTextStyles.ui(
+                size: 12,
+                weight: FontWeight.w600,
+                color: AppColors.atlanticoClaro,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Icon(Icons.close_rounded,
+                size: 14, color: AppColors.atlanticoClaro),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── States ────────────────────────────────────────────────────────────────
+class _EmptyState extends StatelessWidget {
+  final bool hasFilters;
+  final VoidCallback onClear;
+
+  const _EmptyState({required this.hasFilters, required this.onClear});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.movie_filter_outlined,
+                size: 56, color: context.brand.textMuted),
+            const SizedBox(height: 16),
+            Text(
+              hasFilters ? 'Sin resultados' : 'Aún no hay visitas',
+              style: AppTextStyles.displaySection(size: 16),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              hasFilters
+                  ? 'Prueba a ajustar los filtros o la búsqueda.'
+                  : 'En cuanto Jonay y Joana publiquen nuevas visitas las verás aquí.',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.muted(size: 12),
+            ),
+            if (hasFilters) ...[
+              const SizedBox(height: 18),
+              GestureDetector(
+                onTap: onClear,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 18, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: AppColors.atlantico,
+                    borderRadius: BorderRadius.circular(100),
+                  ),
+                  child: Text(
+                    'Quitar filtros',
+                    style: AppTextStyles.ui(
+                      size: 13,
+                      weight: FontWeight.w700,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  final VoidCallback onRetry;
+  const _ErrorState({required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.cloud_off_rounded,
+                size: 48, color: context.brand.textMuted),
+            const SizedBox(height: 14),
+            Text(
+              'No hemos podido cargar las visitas.',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.ui(
+                size: 13,
+                color: context.brand.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 14),
+            GestureDetector(
+              onTap: onRetry,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 18, vertical: 10),
+                decoration: BoxDecoration(
+                  color: AppColors.atlantico,
+                  borderRadius: BorderRadius.circular(100),
+                ),
+                child: Text(
+                  'Reintentar',
+                  style: AppTextStyles.ui(
+                    size: 13,
+                    weight: FontWeight.w700,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/discover/widgets/sort_sheet.dart
+++ b/lib/ui/pages/discover/widgets/sort_sheet.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/config/brand_colors.dart';
+
+enum VisitSort {
+  newest,
+  oldest,
+  ratingDesc,
+  alphaAsc,
+  byCreator,
+}
+
+extension VisitSortMeta on VisitSort {
+  String get label {
+    switch (this) {
+      case VisitSort.newest:
+        return 'Más recientes';
+      case VisitSort.oldest:
+        return 'Más antiguas';
+      case VisitSort.ratingDesc:
+        return 'Mejor valoradas';
+      case VisitSort.alphaAsc:
+        return 'A-Z restaurante';
+      case VisitSort.byCreator:
+        return 'Por autor';
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case VisitSort.newest:
+        return Icons.schedule_rounded;
+      case VisitSort.oldest:
+        return Icons.history_rounded;
+      case VisitSort.ratingDesc:
+        return Icons.star_rounded;
+      case VisitSort.alphaAsc:
+        return Icons.sort_by_alpha_rounded;
+      case VisitSort.byCreator:
+        return Icons.person_rounded;
+    }
+  }
+}
+
+class VisitSortSheet extends StatelessWidget {
+  final VisitSort current;
+
+  const VisitSortSheet({super.key, required this.current});
+
+  static Future<VisitSort?> show({
+    required BuildContext context,
+    required VisitSort current,
+  }) {
+    return showModalBottomSheet<VisitSort>(
+      context: context,
+      backgroundColor: context.brand.elevated,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      builder: (_) => VisitSortSheet(current: current),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(8, 6, 8, 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                margin: const EdgeInsets.only(top: 4, bottom: 14),
+                width: 44,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: context.brand.textMuted.withOpacity(0.4),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: Text(
+                'Ordenar por',
+                style: AppTextStyles.displaySection(size: 16),
+              ),
+            ),
+            for (final s in VisitSort.values)
+              _SortRow(
+                option: s,
+                selected: s == current,
+                onTap: () => Navigator.pop(context, s),
+              ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SortRow extends StatelessWidget {
+  final VisitSort option;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _SortRow({
+    required this.option,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = selected
+        ? AppColors.atlanticoClaro
+        : context.brand.textPrimary;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+        child: Row(
+          children: [
+            Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: selected
+                    ? AppColors.atlantico.withOpacity(0.18)
+                    : context.brand.surface,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: selected
+                      ? AppColors.atlantico.withOpacity(0.45)
+                      : context.brand.border,
+                ),
+              ),
+              child: Icon(option.icon, size: 18, color: fg),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Text(
+                option.label,
+                style: AppTextStyles.ui(
+                  size: 14,
+                  weight:
+                      selected ? FontWeight.w700 : FontWeight.w500,
+                  color: fg,
+                ),
+              ),
+            ),
+            if (selected)
+              Icon(Icons.check_rounded,
+                  size: 18, color: AppColors.atlanticoClaro),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/discover/widgets/visit_filter_sheet.dart
+++ b/lib/ui/pages/discover/widgets/visit_filter_sheet.dart
@@ -1,0 +1,356 @@
+import 'package:flutter/material.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/config/brand_colors.dart';
+
+/// Active filters for the visits browser.
+class VisitFilterValues {
+  final Set<String> creators;
+  final Set<String> sentiments; // muy_positivo | positivo | neutro | negativo
+  final Set<String> zones;
+  final bool onlyWithVideo;
+
+  const VisitFilterValues({
+    this.creators = const {},
+    this.sentiments = const {},
+    this.zones = const {},
+    this.onlyWithVideo = false,
+  });
+
+  int get count =>
+      creators.length +
+      sentiments.length +
+      zones.length +
+      (onlyWithVideo ? 1 : 0);
+
+  VisitFilterValues copyWith({
+    Set<String>? creators,
+    Set<String>? sentiments,
+    Set<String>? zones,
+    bool? onlyWithVideo,
+  }) =>
+      VisitFilterValues(
+        creators: creators ?? this.creators,
+        sentiments: sentiments ?? this.sentiments,
+        zones: zones ?? this.zones,
+        onlyWithVideo: onlyWithVideo ?? this.onlyWithVideo,
+      );
+}
+
+const Map<String, String> kSentimentLabels = {
+  'muy_positivo': 'Muy positivo',
+  'positivo': 'Positivo',
+  'neutro': 'Neutro',
+  'negativo': 'Negativo',
+};
+
+class VisitFilterSheet extends StatefulWidget {
+  final VisitFilterValues initial;
+  final List<String> creators;
+  final List<String> zones;
+
+  const VisitFilterSheet({
+    super.key,
+    required this.initial,
+    required this.creators,
+    required this.zones,
+  });
+
+  static Future<VisitFilterValues?> show({
+    required BuildContext context,
+    required VisitFilterValues initial,
+    required List<String> creators,
+    required List<String> zones,
+  }) {
+    return showModalBottomSheet<VisitFilterValues>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: context.brand.elevated,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      builder: (_) => VisitFilterSheet(
+        initial: initial,
+        creators: creators,
+        zones: zones,
+      ),
+    );
+  }
+
+  @override
+  State<VisitFilterSheet> createState() => _VisitFilterSheetState();
+}
+
+class _VisitFilterSheetState extends State<VisitFilterSheet> {
+  late VisitFilterValues _values;
+
+  @override
+  void initState() {
+    super.initState();
+    _values = widget.initial;
+  }
+
+  void _toggleCreator(String c) {
+    setState(() {
+      final next = Set<String>.from(_values.creators);
+      next.contains(c) ? next.remove(c) : next.add(c);
+      _values = _values.copyWith(creators: next);
+    });
+  }
+
+  void _toggleSentiment(String s) {
+    setState(() {
+      final next = Set<String>.from(_values.sentiments);
+      next.contains(s) ? next.remove(s) : next.add(s);
+      _values = _values.copyWith(sentiments: next);
+    });
+  }
+
+  void _toggleZone(String z) {
+    setState(() {
+      final next = Set<String>.from(_values.zones);
+      next.contains(z) ? next.remove(z) : next.add(z);
+      _values = _values.copyWith(zones: next);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: size.height * 0.86),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Grabber
+            Container(
+              margin: const EdgeInsets.only(top: 8, bottom: 4),
+              width: 44,
+              height: 4,
+              decoration: BoxDecoration(
+                color: context.brand.textMuted.withOpacity(0.4),
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ),
+            // Header
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Filtrar visitas',
+                      style: AppTextStyles.displaySection(size: 18),
+                    ),
+                  ),
+                  if (_values.count > 0)
+                    GestureDetector(
+                      onTap: () => setState(
+                          () => _values = const VisitFilterValues()),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 6, vertical: 6),
+                        child: Text(
+                          'Limpiar todo',
+                          style: AppTextStyles.ui(
+                            size: 13,
+                            weight: FontWeight.w600,
+                            color: AppColors.atlanticoClaro,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 4),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (widget.creators.isNotEmpty) ...[
+                      _SectionTitle('Creador'),
+                      const SizedBox(height: 10),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          for (final c in widget.creators)
+                            _PickerChip(
+                              label: c,
+                              selected: _values.creators.contains(c),
+                              onTap: () => _toggleCreator(c),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 22),
+                    ],
+                    _SectionTitle('Sentimiento'),
+                    const SizedBox(height: 10),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        for (final entry in kSentimentLabels.entries)
+                          _PickerChip(
+                            label: entry.value,
+                            selected: _values.sentiments.contains(entry.key),
+                            color: _sentimentColor(entry.key),
+                            onTap: () => _toggleSentiment(entry.key),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 22),
+                    if (widget.zones.isNotEmpty) ...[
+                      _SectionTitle('Zona'),
+                      const SizedBox(height: 10),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          for (final z in widget.zones)
+                            _PickerChip(
+                              label: z,
+                              selected: _values.zones.contains(z),
+                              onTap: () => _toggleZone(z),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 22),
+                    ],
+                    _SectionTitle('Otros'),
+                    const SizedBox(height: 8),
+                    SwitchListTile(
+                      contentPadding: EdgeInsets.zero,
+                      activeColor: AppColors.atlanticoClaro,
+                      value: _values.onlyWithVideo,
+                      onChanged: (v) => setState(() =>
+                          _values = _values.copyWith(onlyWithVideo: v)),
+                      title: Text(
+                        'Solo visitas con vídeo',
+                        style: AppTextStyles.ui(
+                          size: 14,
+                          color: context.brand.textPrimary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            // Footer apply
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 6, 16, 12),
+              child: SizedBox(
+                width: double.infinity,
+                height: 52,
+                child: ElevatedButton(
+                  onPressed: () => Navigator.pop(context, _values),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.atlantico,
+                    foregroundColor: Colors.white,
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(100),
+                    ),
+                  ),
+                  child: Text(
+                    _values.count == 0
+                        ? 'Ver visitas'
+                        : 'Aplicar · ${_values.count} filtro${_values.count == 1 ? '' : 's'}',
+                    style: AppTextStyles.ui(
+                      size: 14,
+                      weight: FontWeight.w700,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color? _sentimentColor(String s) {
+    switch (s) {
+      case 'muy_positivo':
+        return AppColors.laurisilva;
+      case 'positivo':
+        return AppColors.atlantico;
+      case 'neutro':
+        return AppColors.arena;
+      case 'negativo':
+        return AppColors.mojo;
+    }
+    return null;
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  final String text;
+  const _SectionTitle(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text.toUpperCase(),
+      style: AppTextStyles.eyebrow(
+        size: 11,
+        color: AppColors.atlanticoClaro,
+      ),
+    );
+  }
+}
+
+class _PickerChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+  final Color? color;
+
+  const _PickerChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = color ?? AppColors.atlantico;
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 160),
+        padding:
+            const EdgeInsets.symmetric(horizontal: 14, vertical: 9),
+        decoration: BoxDecoration(
+          color: selected
+              ? accent.withOpacity(0.18)
+              : context.brand.surface,
+          borderRadius: BorderRadius.circular(100),
+          border: Border.all(
+            color: selected
+                ? accent.withOpacity(0.55)
+                : context.brand.borderStrong,
+            width: selected ? 1.4 : 1,
+          ),
+        ),
+        child: Text(
+          label,
+          style: AppTextStyles.ui(
+            size: 13,
+            weight: selected ? FontWeight.w700 : FontWeight.w500,
+            color: selected ? accent : context.brand.textPrimary,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/discover/widgets/visit_list_tile.dart
+++ b/lib/ui/pages/discover/widgets/visit_list_tile.dart
@@ -1,0 +1,796 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/config/brand_colors.dart';
+import 'package:guachinches/data/model/Visit.dart';
+
+/// Tarjeta horizontal de visita pensada para listado vertical (browser),
+/// **expandible**: tap → despliega resumen completo, platos destacados,
+/// highlights / lowlights, servicios y CTA para abrir la visita.
+class VisitListTile extends StatefulWidget {
+  final Visit visit;
+  /// Navegación al detalle (la usa el botón "Ver visita completa").
+  final VoidCallback onTap;
+
+  const VisitListTile({
+    super.key,
+    required this.visit,
+    required this.onTap,
+  });
+
+  @override
+  State<VisitListTile> createState() => _VisitListTileState();
+}
+
+class _VisitListTileState extends State<VisitListTile> {
+  bool _pressed = false;
+  bool _expanded = false;
+
+  void _toggle() => setState(() => _expanded = !_expanded);
+
+  @override
+  Widget build(BuildContext context) {
+    final v = widget.visit;
+    final brand = context.brand;
+
+    final photoUrl = v.thumbnail?.isNotEmpty == true
+        ? v.thumbnail
+        : v.restaurant?.mainFoto;
+    final name = (v.name?.isNotEmpty == true
+            ? v.name!
+            : v.restaurant?.nombre ?? '')
+        .trim();
+    final hasYoutube = (v.videoUrl != null && v.videoUrl!.isNotEmpty) ||
+        (v.youtubeVideoId != null && v.youtubeVideoId!.isNotEmpty);
+    final caption = _captionFor(v);
+    final zone = (v.zone?.isNotEmpty == true ? v.zone : v.restaurant?.municipio) ?? '';
+    final rating = v.ratingImplicit;
+    final priceRange = v.priceRange?.trim();
+    final sentiment = v.overallSentiment;
+    final dateLabel = _dateLabel(v.publishedAt ?? v.createdAt);
+
+    return GestureDetector(
+      // Tap fuera del botón de despliegue → abrir detalle.
+      onTapDown: (_) => setState(() => _pressed = true),
+      onTapUp: (_) => setState(() => _pressed = false),
+      onTapCancel: () => setState(() => _pressed = false),
+      onTap: widget.onTap,
+      child: AnimatedScale(
+        scale: _pressed ? 0.985 : 1.0,
+        duration: const Duration(milliseconds: 130),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+          decoration: BoxDecoration(
+            color: brand.surface,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: _expanded
+                  ? AppColors.atlantico.withOpacity(0.45)
+                  : brand.border,
+              width: _expanded ? 1.4 : 1,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(_expanded ? 0.10 : 0.05),
+                blurRadius: _expanded ? 18 : 12,
+                offset: const Offset(0, 3),
+              ),
+            ],
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // ── Collapsed row ──────────────────────────────────────────
+              Padding(
+                padding: const EdgeInsets.all(10),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _Thumbnail(
+                      url: photoUrl,
+                      hasVideo: hasYoutube,
+                      fallbackColor: brand.elevated,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          _CreatorRow(
+                            creator: v.creator,
+                            date: dateLabel,
+                          ),
+                          const SizedBox(height: 6),
+                          if (name.isNotEmpty)
+                            Text(
+                              name.toUpperCase(),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: AppTextStyles.displaySection(size: 15),
+                            ),
+                          const SizedBox(height: 5),
+                          _MetaLine(
+                            rating: rating,
+                            zone: zone,
+                            priceRange: priceRange,
+                            sentiment: sentiment,
+                          ),
+                          if (caption != null &&
+                              caption.isNotEmpty &&
+                              !_expanded) ...[
+                            const SizedBox(height: 7),
+                            Text(
+                              '"$caption"',
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: AppTextStyles.editorial(
+                                size: 12,
+                                color: brand.textSecondary,
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 6),
+                    // Solo este botón controla expandir/colapsar; el resto
+                    // de la tarjeta navega al detalle.
+                    GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: _toggle,
+                      child: Padding(
+                        padding: const EdgeInsets.all(6),
+                        child: AnimatedRotation(
+                          turns: _expanded ? 0.5 : 0.0,
+                          duration: const Duration(milliseconds: 220),
+                          child: Container(
+                            width: 28,
+                            height: 28,
+                            decoration: BoxDecoration(
+                              color: _expanded
+                                  ? AppColors.atlantico.withOpacity(0.18)
+                                  : brand.elevated,
+                              shape: BoxShape.circle,
+                            ),
+                            child: Icon(
+                              Icons.keyboard_arrow_down_rounded,
+                              size: 18,
+                              color: _expanded
+                                  ? AppColors.atlanticoClaro
+                                  : brand.textPrimary,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              // ── Expanded body ──────────────────────────────────────────
+              ClipRect(
+                child: AnimatedAlign(
+                  alignment: Alignment.topCenter,
+                  duration: const Duration(milliseconds: 240),
+                  curve: Curves.easeOut,
+                  heightFactor: _expanded ? 1 : 0,
+                  child: AnimatedOpacity(
+                    duration: const Duration(milliseconds: 180),
+                    opacity: _expanded ? 1.0 : 0.0,
+                    child: _ExpandedBody(
+                      visit: v,
+                      onOpen: widget.onTap,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String? _captionFor(Visit v) {
+    if (v.extraText?.isNotEmpty == true) return v.extraText;
+    if (v.quotes.isNotEmpty) return v.quotes.first.text;
+    if (v.summary?.isNotEmpty == true) return v.summary;
+    if (v.highlights.isNotEmpty) return v.highlights.first;
+    return null;
+  }
+
+  static String _dateLabel(String? raw) {
+    if (raw == null || raw.isEmpty) return '';
+    final dt = DateTime.tryParse(raw);
+    if (dt == null) return '';
+    final now = DateTime.now();
+    final diff = now.difference(dt).inDays;
+    if (diff < 1) return 'Hoy';
+    if (diff < 2) return 'Ayer';
+    if (diff < 7) return 'Hace ${diff}d';
+    if (diff < 30) {
+      final w = (diff / 7).floor();
+      return 'Hace ${w}sem';
+    }
+    const months = [
+      'ene', 'feb', 'mar', 'abr', 'may', 'jun',
+      'jul', 'ago', 'sep', 'oct', 'nov', 'dic',
+    ];
+    if (dt.year == now.year) {
+      return '${dt.day} ${months[dt.month - 1]}';
+    }
+    return '${dt.day} ${months[dt.month - 1]} ${dt.year}';
+  }
+}
+
+// ── Expanded body ──────────────────────────────────────────────────────────
+class _ExpandedBody extends StatelessWidget {
+  final Visit visit;
+  final VoidCallback onOpen;
+
+  const _ExpandedBody({required this.visit, required this.onOpen});
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final v = visit;
+
+    final summary = v.summary?.trim();
+    final topDishes = v.dishes
+        .where((d) => d.isTop || d.sentiment == 'loved')
+        .toList();
+    final fallbackDishes =
+        topDishes.isEmpty ? v.dishes.take(4).toList() : topDishes.take(4).toList();
+    final highlights = v.highlights.take(3).toList();
+    final lowlights = v.lowlights.take(2).toList();
+    final services = v.services.take(6).toList();
+    final quote = v.quotes.isNotEmpty ? v.quotes.first.text : null;
+    final hasAnyExtra = (summary != null && summary.isNotEmpty) ||
+        fallbackDishes.isNotEmpty ||
+        highlights.isNotEmpty ||
+        lowlights.isNotEmpty ||
+        services.isNotEmpty ||
+        (quote != null && quote.isNotEmpty);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(14, 0, 14, 14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            height: 1,
+            margin: const EdgeInsets.only(bottom: 14),
+            color: brand.border,
+          ),
+          if (quote != null && quote.isNotEmpty) ...[
+            _Quote(text: quote, brand: brand),
+            const SizedBox(height: 14),
+          ],
+          if (summary != null && summary.isNotEmpty) ...[
+            Text(
+              summary,
+              style: AppTextStyles.ui(
+                size: 13,
+                color: brand.textPrimary,
+              ).copyWith(height: 1.45),
+            ),
+            const SizedBox(height: 14),
+          ],
+          if (fallbackDishes.isNotEmpty) ...[
+            _SectionLabel(
+              icon: Icons.local_dining_rounded,
+              label: topDishes.isNotEmpty ? 'PLATOS DESTACADOS' : 'PLATOS',
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final d in fallbackDishes) _DishChip(dish: d),
+              ],
+            ),
+            const SizedBox(height: 14),
+          ],
+          if (highlights.isNotEmpty) ...[
+            _SectionLabel(
+              icon: Icons.thumb_up_rounded,
+              label: 'LO MEJOR',
+              color: AppColors.laurisilva,
+            ),
+            const SizedBox(height: 6),
+            for (final h in highlights)
+              _BulletRow(
+                icon: Icons.check_rounded,
+                color: AppColors.laurisilva,
+                text: h,
+              ),
+            const SizedBox(height: 12),
+          ],
+          if (lowlights.isNotEmpty) ...[
+            _SectionLabel(
+              icon: Icons.thumb_down_rounded,
+              label: 'LO MENOS BUENO',
+              color: AppColors.mojo,
+            ),
+            const SizedBox(height: 6),
+            for (final l in lowlights)
+              _BulletRow(
+                icon: Icons.close_rounded,
+                color: AppColors.mojo,
+                text: l,
+              ),
+            const SizedBox(height: 12),
+          ],
+          if (services.isNotEmpty) ...[
+            _SectionLabel(
+              icon: Icons.room_service_rounded,
+              label: 'SERVICIOS',
+            ),
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: [
+                for (final s in services) _ServiceChip(label: s),
+              ],
+            ),
+            const SizedBox(height: 14),
+          ],
+          if (!hasAnyExtra)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Text(
+                'No hay información adicional disponible.',
+                style: AppTextStyles.muted(size: 12),
+              ),
+            ),
+          // Action button
+          SizedBox(
+            width: double.infinity,
+            height: 46,
+            child: ElevatedButton.icon(
+              onPressed: onOpen,
+              icon: const Icon(Icons.play_arrow_rounded,
+                  size: 20, color: Colors.white),
+              label: Text(
+                'Ver visita completa',
+                style: AppTextStyles.ui(
+                  size: 13,
+                  weight: FontWeight.w700,
+                  color: Colors.white,
+                ),
+              ),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.atlantico,
+                foregroundColor: Colors.white,
+                elevation: 0,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(100),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color? color;
+
+  const _SectionLabel({
+    required this.icon,
+    required this.label,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = color ?? AppColors.atlanticoClaro;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 13, color: c),
+        const SizedBox(width: 6),
+        Text(
+          label,
+          style: AppTextStyles.eyebrow(size: 11, color: c),
+        ),
+      ],
+    );
+  }
+}
+
+class _BulletRow extends StatelessWidget {
+  final IconData icon;
+  final Color color;
+  final String text;
+
+  const _BulletRow({
+    required this.icon,
+    required this.color,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Icon(icon, size: 14, color: color),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              text,
+              style: AppTextStyles.ui(
+                size: 12,
+                color: context.brand.textPrimary,
+              ).copyWith(height: 1.35),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DishChip extends StatelessWidget {
+  final VisitDish dish;
+  const _DishChip({required this.dish});
+
+  @override
+  Widget build(BuildContext context) {
+    final isTop = dish.isTop || dish.sentiment == 'loved';
+    final color = isTop ? AppColors.sol : AppColors.atlantico;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(100),
+        border: Border.all(color: color.withOpacity(0.4)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (isTop) ...[
+            const Icon(Icons.star_rounded, size: 13, color: AppColors.sol),
+            const SizedBox(width: 4),
+          ],
+          Flexible(
+            child: Text(
+              dish.name,
+              style: AppTextStyles.ui(
+                size: 12,
+                weight: FontWeight.w700,
+                color: color,
+              ),
+            ),
+          ),
+          if (dish.price != null) ...[
+            const SizedBox(width: 6),
+            Text(
+              '${dish.price}€',
+              style: AppTextStyles.ui(
+                size: 11,
+                weight: FontWeight.w600,
+                color: color.withOpacity(0.85),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ServiceChip extends StatelessWidget {
+  final String label;
+  const _ServiceChip({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+      decoration: BoxDecoration(
+        color: brand.elevated,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: brand.border),
+      ),
+      child: Text(
+        label,
+        style: AppTextStyles.ui(
+          size: 11,
+          weight: FontWeight.w500,
+          color: brand.textPrimary,
+        ),
+      ),
+    );
+  }
+}
+
+class _Quote extends StatelessWidget {
+  final String text;
+  final BrandColors brand;
+
+  const _Quote({required this.text, required this.brand});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Positioned(
+          left: -2,
+          top: -10,
+          child: Text(
+            '"',
+            style: TextStyle(
+              fontFamily: 'SF Pro Display',
+              fontSize: 40,
+              height: 1,
+              fontWeight: FontWeight.w700,
+              color: brand.textSecondary.withOpacity(0.18),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(left: 16, top: 4),
+          child: Text(
+            text,
+            style: AppTextStyles.editorial(
+              size: 13,
+              color: brand.textPrimary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Thumbnail ──────────────────────────────────────────────────────────────
+class _Thumbnail extends StatelessWidget {
+  final String? url;
+  final bool hasVideo;
+  final Color fallbackColor;
+
+  const _Thumbnail({
+    required this.url,
+    required this.hasVideo,
+    required this.fallbackColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(14),
+      child: SizedBox(
+        width: 110,
+        height: 110,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            if (url != null && url!.isNotEmpty)
+              CachedNetworkImage(
+                imageUrl: url!,
+                fit: BoxFit.cover,
+                memCacheWidth: 320,
+                placeholder: (_, __) => Container(color: fallbackColor),
+                errorWidget: (_, __, ___) => Container(color: fallbackColor),
+              )
+            else
+              Container(color: fallbackColor),
+            if (hasVideo) ...[
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      Colors.black.withOpacity(0),
+                      Colors.black.withOpacity(0.32),
+                    ],
+                  ),
+                ),
+              ),
+              Center(
+                child: Container(
+                  width: 38,
+                  height: 38,
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.92),
+                    shape: BoxShape.circle,
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.2),
+                        blurRadius: 8,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: const Icon(
+                    Icons.play_arrow_rounded,
+                    size: 22,
+                    color: Color(0xFF1A1A1A),
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Creator row ────────────────────────────────────────────────────────────
+class _CreatorRow extends StatelessWidget {
+  final String? creator;
+  final String date;
+
+  const _CreatorRow({required this.creator, required this.date});
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final hasCreator = creator?.isNotEmpty == true;
+    return Row(
+      children: [
+        if (hasCreator)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: AppColors.atlantico.withOpacity(0.14),
+              borderRadius: BorderRadius.circular(100),
+              border: Border.all(
+                color: AppColors.atlantico.withOpacity(0.4),
+              ),
+            ),
+            child: Text(
+              'POR ${creator!.toUpperCase()}',
+              style: AppTextStyles.eyebrow(
+                size: 10,
+                color: AppColors.atlanticoClaro,
+              ),
+            ),
+          ),
+        if (hasCreator && date.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 6),
+            child: Text(
+              '·',
+              style: AppTextStyles.ui(size: 10, color: brand.textMuted),
+            ),
+          ),
+        if (date.isNotEmpty)
+          Text(
+            date,
+            style: AppTextStyles.muted(size: 11),
+          ),
+      ],
+    );
+  }
+}
+
+// ── Meta line ──────────────────────────────────────────────────────────────
+class _MetaLine extends StatelessWidget {
+  final double? rating;
+  final String zone;
+  final String? priceRange;
+  final String? sentiment;
+
+  const _MetaLine({
+    required this.rating,
+    required this.zone,
+    required this.priceRange,
+    required this.sentiment,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final children = <Widget>[];
+    if (rating != null && rating! > 0) {
+      children.add(
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.star_rounded, size: 13, color: AppColors.sol),
+            const SizedBox(width: 3),
+            Text(
+              rating!.toStringAsFixed(1),
+              style: AppTextStyles.ui(
+                size: 12,
+                weight: FontWeight.w700,
+                color: AppColors.sol,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    if (zone.isNotEmpty) {
+      if (children.isNotEmpty) children.add(_dot(context));
+      children.add(Flexible(
+        child: Text(
+          zone,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTextStyles.ui(
+            size: 12,
+            color: brand.textPrimary,
+          ),
+        ),
+      ));
+    }
+    if (priceRange != null && priceRange!.isNotEmpty) {
+      if (children.isNotEmpty) children.add(_dot(context));
+      children.add(Text(
+        priceRange!.replaceAll(r'$', '€'),
+        style: AppTextStyles.ui(
+          size: 12,
+          weight: FontWeight.w700,
+          color: brand.textSecondary,
+        ),
+      ));
+    }
+    final sentimentChip = _sentimentChip(sentiment);
+    if (sentimentChip != null) {
+      if (children.isNotEmpty) children.add(const SizedBox(width: 8));
+      children.add(sentimentChip);
+    }
+    if (children.isEmpty) return const SizedBox.shrink();
+    return Wrap(
+      crossAxisAlignment: WrapCrossAlignment.center,
+      runSpacing: 4,
+      children: children,
+    );
+  }
+
+  Widget _dot(BuildContext context) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6),
+        child: Text(
+          '·',
+          style: AppTextStyles.ui(
+            size: 12,
+            color: context.brand.textMuted,
+          ),
+        ),
+      );
+
+  Widget? _sentimentChip(String? sentiment) {
+    if (sentiment == null || sentiment.isEmpty) return null;
+    final (label, color) = switch (sentiment) {
+      'muy_positivo' => ('Muy bueno', AppColors.laurisilva),
+      'positivo' => ('Bueno', AppColors.atlantico),
+      'neutro' => ('Neutro', AppColors.arena),
+      'negativo' => ('Flojo', AppColors.mojo),
+      _ => (null, null),
+    };
+    if (label == null || color == null) return null;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.14),
+        borderRadius: BorderRadius.circular(100),
+        border: Border.all(color: color.withOpacity(0.4)),
+      ),
+      child: Text(
+        label.toUpperCase(),
+        style: AppTextStyles.chipLabel(size: 9, color: color),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/favoritos/favoritos.dart
+++ b/lib/ui/pages/favoritos/favoritos.dart
@@ -1,53 +1,346 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_rating_bar/flutter_rating_bar.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/config/brand_colors.dart';
 import 'package:guachinches/data/HttpRemoteRepository.dart';
-import 'package:guachinches/data/RemoteRepository.dart';
-import 'package:guachinches/data/cubit/user/user_cubit.dart';
-import 'package:guachinches/data/cubit/user/user_state.dart';
-import 'package:guachinches/globalMethods.dart';
-import 'package:guachinches/ui/pages/login/login.dart';
-import 'package:guachinches/ui/pages/valoraciones/valoraciones_presenter.dart';
-import 'package:http/http.dart';
+import 'package:guachinches/data/local/sql_lite_local_repository.dart';
+import 'package:guachinches/data/model/restaurant.dart';
+import 'package:guachinches/ui/components/open_status_badge.dart';
+import 'package:guachinches/ui/pages/restaurant_detail/restaurant_detail_screen.dart';
+import 'package:http/http.dart' as http;
 
 class FavoritosPage extends StatefulWidget {
+  const FavoritosPage({super.key});
+
   @override
-  _FavoritosPageState createState() => _FavoritosPageState();
+  State<FavoritosPage> createState() => _FavoritosPageState();
 }
 
 class _FavoritosPageState extends State<FavoritosPage> {
+  final _localRepo = SqlLiteLocalRepository();
+  late final HttpRemoteRepository _repo =
+      HttpRemoteRepository(http.Client());
+
+  bool _loading = true;
+  List<Restaurant> _restaurants = const [];
 
   @override
   void initState() {
     super.initState();
+    _load();
   }
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: CupertinoPageScaffold(
-          child: CustomScrollView(
-            slivers: [
-              const CupertinoSliverNavigationBar(
-                largeTitle: Text('Favoritos'),
-              ),
-              SliverFillRemaining(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.only(top:32.0),
-                      child: Center(child: Text('Sin favoritos')),
-                    ),
-                    SizedBox(height: 20.0),
-                  ],
-                ),
-              )
-            ],
-          )
+
+  Future<void> _load() async {
+    if (mounted) setState(() => _loading = true);
+    try {
+      final favs = await _localRepo.getRestaurants();
+      final futures = favs.map((f) async {
+        try {
+          final r = await _repo.getRestaurantById(f.restaurantId);
+          r.id = f.restaurantId;
+          return r;
+        } catch (_) {
+          return null;
+        }
+      });
+      final results = await Future.wait(futures);
+      final list = results.whereType<Restaurant>().toList();
+      if (!mounted) return;
+      setState(() {
+        _restaurants = list;
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _remove(Restaurant r) async {
+    await _localRepo.removeRestaurant(r.id);
+    if (!mounted) return;
+    setState(() {
+      _restaurants = _restaurants.where((x) => x.id != r.id).toList();
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('"${r.nombre}" eliminado de favoritos'),
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: context.brand.elevated,
+        action: SnackBarAction(
+          label: 'Deshacer',
+          textColor: AppColors.atlanticoClaro,
+          onPressed: () async {
+            await _localRepo.insertRestaurant(r.id);
+            if (!mounted) return;
+            setState(() => _restaurants = [..._restaurants, r]);
+          },
+        ),
       ),
     );
   }
 
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Scaffold(
+      backgroundColor: brand.base,
+      appBar: AppBar(
+        backgroundColor: brand.base,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back_rounded, color: brand.textPrimary),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Favoritos',
+          style: AppTextStyles.displaySection(size: 13),
+        ),
+        centerTitle: true,
+      ),
+      body: RefreshIndicator(
+        color: AppColors.atlantico,
+        backgroundColor: brand.surface,
+        onRefresh: _load,
+        child: _buildBody(brand),
+      ),
+    );
+  }
+
+  Widget _buildBody(dynamic brand) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_restaurants.isEmpty) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 80),
+          _EmptyState(),
+        ],
+      );
+    }
+    return ListView.separated(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+      itemCount: _restaurants.length + 1,
+      separatorBuilder: (_, __) => const SizedBox(height: 10),
+      itemBuilder: (_, i) {
+        if (i == 0) {
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 6, top: 4),
+            child: Text(
+              '${_restaurants.length} ${_restaurants.length == 1 ? "local guardado" : "locales guardados"}',
+              style: AppTextStyles.eyebrow(
+                size: 11,
+                color: brand.textMuted,
+              ),
+            ),
+          );
+        }
+        final r = _restaurants[i - 1];
+        return _FavoriteCard(
+          restaurant: r,
+          onTap: () => Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => RestaurantDetailScreen(id: r.id),
+            ),
+          ).then((_) => _load()),
+          onRemove: () => _remove(r),
+        );
+      },
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+class _FavoriteCard extends StatelessWidget {
+  final Restaurant restaurant;
+  final VoidCallback onTap;
+  final VoidCallback onRemove;
+
+  const _FavoriteCard({
+    required this.restaurant,
+    required this.onTap,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final r = restaurant;
+    final hasImage = r.mainFoto.isNotEmpty;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: Container(
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: brand.surface,
+            border: Border.all(color: brand.borderStrong),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(10),
+                child: SizedBox(
+                  width: 88,
+                  height: 88,
+                  child: hasImage
+                      ? Image.network(
+                          r.mainFoto,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) =>
+                              _ImageFallback(brand: brand),
+                        )
+                      : _ImageFallback(brand: brand),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 2),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        r.nombre,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTextStyles.displayHero(size: 16),
+                      ),
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          Icon(Icons.star_rounded,
+                              size: 13, color: AppColors.sol),
+                          const SizedBox(width: 2),
+                          Text(
+                            r.avgRating > 0
+                                ? r.avgRating.toStringAsFixed(1)
+                                : 'n/d',
+                            style: AppTextStyles.ui(
+                              size: 12,
+                              weight: FontWeight.w700,
+                              color: brand.textPrimary,
+                            ),
+                          ),
+                          if (r.municipio.isNotEmpty) ...[
+                            const SizedBox(width: 6),
+                            Text('·',
+                                style: AppTextStyles.ui(
+                                    size: 12, color: brand.textMuted)),
+                            const SizedBox(width: 6),
+                            Flexible(
+                              child: Text(
+                                r.municipio,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: AppTextStyles.ui(
+                                  size: 12,
+                                  color: brand.textSecondary,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                      const SizedBox(height: 6),
+                      OpenStatusBadge(
+                        horariosJson: r.horariosJson,
+                        fallbackOpen: r.open,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(
+                  Icons.bookmark_rounded,
+                  color: AppColors.atlanticoClaro,
+                  size: 22,
+                ),
+                onPressed: onRemove,
+                tooltip: 'Quitar de favoritos',
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(
+                    minWidth: 36, minHeight: 36),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ImageFallback extends StatelessWidget {
+  final dynamic brand;
+  const _ImageFallback({required this.brand});
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: brand.elevated,
+      alignment: Alignment.center,
+      child: Icon(
+        Icons.restaurant_rounded,
+        color: brand.textMuted,
+        size: 24,
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+class _EmptyState extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          children: [
+            Container(
+              width: 88,
+              height: 88,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: AppColors.atlantico.withOpacity(0.12),
+                borderRadius: BorderRadius.circular(24),
+              ),
+              child: const Icon(
+                Icons.bookmark_outline_rounded,
+                size: 38,
+                color: AppColors.atlanticoClaro,
+              ),
+            ),
+            const SizedBox(height: 18),
+            Text(
+              'Aún no tienes favoritos',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.displayHero(size: 22),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Toca el icono de marcador en cualquier restaurante para guardarlo y tenerlo siempre a mano.',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.ui(
+                size: 13,
+                color: brand.textSecondary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/lib/ui/pages/home/home.dart
+++ b/lib/ui/pages/home/home.dart
@@ -184,10 +184,11 @@ class _HomeState extends State<Home> with WidgetsBindingObserver implements Home
     presenter.getSurveyRestaurants();
     context.read<LocationCubit>().requestLocation();
 
-    SurveyPopup.showIfNeeded(
-      context,
-      onVoted: () => presenter.getSurveyResults(allSurveyRestaurants),
-    );
+    // Premios Donde Comer Canarias 2026 — popup pausado.
+    // SurveyPopup.showIfNeeded(
+    //   context,
+    //   onVoted: () => presenter.getSurveyResults(allSurveyRestaurants),
+    // );
 
     // Escucha el desplazamiento del scroll para cambiar el fondo de la app bar
     _scrollController.addListener(() {
@@ -396,9 +397,10 @@ class _HomeState extends State<Home> with WidgetsBindingObserver implements Home
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  SurveyBanner(
-                    onVoted: () => presenter.getSurveyResults(allSurveyRestaurants),
-                  ),
+                  // Premios Donde Comer Canarias 2026 — banner inline pausado.
+                  // SurveyBanner(
+                  //   onVoted: () => presenter.getSurveyResults(allSurveyRestaurants),
+                  // ),
                   if (surveyRanking != null &&
                       (surveyGuachinchesTradicionales.isNotEmpty ||
                           surveyGuachinchesModernos.isNotEmpty))

--- a/lib/ui/pages/listas/listas_screen.dart
+++ b/lib/ui/pages/listas/listas_screen.dart
@@ -6,6 +6,7 @@ import 'package:guachinches/config/brand_colors.dart';
 import 'package:guachinches/data/cubit/new_home/curated_lists_cubit.dart';
 import 'package:guachinches/data/cubit/new_home/new_home_filters_cubit.dart';
 import 'package:guachinches/data/model/curated_list.dart';
+import 'package:guachinches/ui/pages/curated_list_detail/curated_list_detail_screen.dart';
 
 /// Pantalla "Listas": catálogo de recopilatorios editoriales.
 /// Reusa los tokens de diseño (light/dark) y el modelo de [CuratedList].
@@ -30,6 +31,14 @@ class _ListasScreenState extends State<ListasScreen> {
     cubit.loadForIsland(null);
     // Pre-seleccionar la isla activa del usuario para filtrar localmente.
     _islandIdFilter = context.read<NewHomeFiltersCubit>().state.islandId;
+  }
+
+  void _openList(CuratedList list) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => CuratedListDetailScreen(list: list),
+      ),
+    );
   }
 
   List<CuratedList> _applyFilters(List<CuratedList> all) {
@@ -104,7 +113,7 @@ class _ListasScreenState extends State<ListasScreen> {
                       sliver: SliverToBoxAdapter(
                         child: _FeaturedListCard(
                           list: featured,
-                          onTap: () {},
+                          onTap: () => _openList(featured),
                         ),
                       ),
                     ),
@@ -133,7 +142,7 @@ class _ListasScreenState extends State<ListasScreen> {
                       delegate: SliverChildBuilderDelegate(
                         (_, i) => _GridListCard(
                           list: rest[i],
-                          onTap: () {},
+                          onTap: () => _openList(rest[i]),
                         ),
                         childCount: rest.length,
                       ),
@@ -156,18 +165,20 @@ class _ListasScreenState extends State<ListasScreen> {
 class _Header extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final canPop = Navigator.of(context).canPop();
     return Padding(
-      padding: const EdgeInsets.fromLTRB(8, 8, 12, 4),
+      padding: EdgeInsets.fromLTRB(canPop ? 8 : 20, 8, 12, 4),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          IconButton(
-            icon: Icon(
-              Icons.arrow_back_rounded,
-              color: context.brand.textPrimary,
+          if (canPop)
+            IconButton(
+              icon: Icon(
+                Icons.arrow_back_rounded,
+                color: context.brand.textPrimary,
+              ),
+              onPressed: () => Navigator.of(context).maybePop(),
             ),
-            onPressed: () => Navigator.of(context).maybePop(),
-          ),
           Expanded(
             child: Padding(
               padding: const EdgeInsets.only(top: 10),

--- a/lib/ui/pages/login/login.dart
+++ b/lib/ui/pages/login/login.dart
@@ -1,253 +1,644 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
 import 'package:guachinches/data/HttpRemoteRepository.dart';
 import 'package:guachinches/data/RemoteRepository.dart';
 import 'package:guachinches/data/cubit/user/user_cubit.dart';
 import 'package:guachinches/globalMethods.dart';
+import 'package:guachinches/ui/pages/discover/discover_screen.dart';
 import 'package:guachinches/ui/pages/listas/listas_screen.dart';
+import 'package:guachinches/ui/pages/login/login_presenter.dart';
 import 'package:guachinches/ui/pages/map/map_search.dart';
 import 'package:guachinches/ui/pages/new_home/new_home_screen.dart';
 import 'package:guachinches/ui/pages/new_home/new_home_tab_scaffold.dart';
-import 'package:guachinches/ui/pages/login/login_presenter.dart';
 import 'package:guachinches/ui/pages/register/register.dart';
-import 'package:guachinches/ui/pages/search_page/search_page.dart';
 import 'package:guachinches/ui/pages/surveyDetails/surveyDetails.dart';
-import 'package:guachinches/ui/pages/video/video.dart';
 import 'package:http/http.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class Login extends StatefulWidget {
   final String mainText;
+  final bool isModal;
 
-  bool isModal = false;
-  Login(this.mainText, {this.isModal = false});
+  const Login(this.mainText, {this.isModal = false, Key? key})
+      : super(key: key);
 
   @override
-  _LoginState createState() => _LoginState();
+  State<Login> createState() => _LoginState();
 }
 
 class _LoginState extends State<Login> implements LoginView {
-  TextEditingController emailController = TextEditingController();
-  TextEditingController passwordController = TextEditingController();
-  late LoginPresenter _presenter;
-  late RemoteRepository _remoteRepository;
-  bool dataError = false;
+  final _emailCtrl = TextEditingController();
+  final _passwordCtrl = TextEditingController();
+  final _emailFocus = FocusNode();
+  final _passwordFocus = FocusNode();
+
+  late final RemoteRepository _repo = HttpRemoteRepository(Client());
+  late final LoginPresenter _presenter =
+      LoginPresenter(_repo, this, context.read<UserCubit>());
+
+  bool _passwordVisible = false;
+  bool _loading = false;
+  String? _emailError;
+  String? _passwordError;
+  String? _formError;
 
   @override
-  void initState() {
-    final userCubit = context.read<UserCubit>();
-    _remoteRepository = HttpRemoteRepository(Client());
-    _presenter = LoginPresenter(_remoteRepository, this, userCubit);
-    super.initState();
+  void dispose() {
+    _emailCtrl.dispose();
+    _passwordCtrl.dispose();
+    _emailFocus.dispose();
+    _passwordFocus.dispose();
+    super.dispose();
   }
 
-  @override
-  Widget build(BuildContext context) {
-    double bottomInsets = MediaQuery.of(context).viewInsets.bottom;
-    return Container(
-        decoration: BoxDecoration(
-            image: DecorationImage(
-                fit: BoxFit.cover,
-                image: AssetImage("assets/images/loginBg.png"))),
-      child: Scaffold(
-        backgroundColor: Colors.transparent,
-        body: ListView(
-          children: [
-        Container(
-        padding: EdgeInsets.symmetric(horizontal: 20.0),
-        height: MediaQuery.of(context).size.height,
-        width: MediaQuery.of(context).size.width,
-        child: Column(
-          children: [
-            SizedBox(
-              height: 20.0,
-            ),
-            GestureDetector(
-              onTap: () => GlobalMethods().removePagesAndGoToNewScreen(
-                  context,
-                  NewHomeTabScaffold(screens: [
-                    const NewHomeScreen(),
-                    const ListasScreen(),
-                    MapSearch(),
-                    VideoScreen(index: 0),
-                    Login("Para ver tu perfíl debes iniciar sesión."),
-                  ])),
-              child: Container(
-                alignment: Alignment.centerRight,
-                child: Icon(
-                  Icons.close,
-                  color: Colors.blueGrey,
-                  size: 40.0,
-                ),
-              ),
-            ),
+  bool _validate() {
+    final email = _emailCtrl.text.trim();
+    final pwd = _passwordCtrl.text;
+    String? eErr;
+    String? pErr;
+    if (email.isEmpty) {
+      eErr = 'Introduce tu email';
+    } else {
+      final re = RegExp(r"^[\w.!#$%&'*+\-/=?^_`{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+");
+      if (!re.hasMatch(email)) eErr = 'Email no válido';
+    }
+    if (pwd.isEmpty) pErr = 'Introduce tu contraseña';
+    setState(() {
+      _emailError = eErr;
+      _passwordError = pErr;
+      _formError = null;
+    });
+    return eErr == null && pErr == null;
+  }
 
-            Align(
-              alignment: Alignment.topLeft,
-              child: Text(
-                widget.mainText,
-                textAlign: TextAlign.start,
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white,
-                  fontSize: 40.0,
-                ),
-              ),
-            ),
-            Text(
-              dataError == true ?"Email o contraseña incorrecta":"",
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 18.0,
-              ),
-            ),
-            SizedBox(
-              height: 30.0,
-            ),
-            Container(
-              height: 62,
-              padding: const EdgeInsets.only(left: 8.0),
-              decoration: BoxDecoration(
-                border: Border(
-                  left: BorderSide(width: 3.0, color: Colors.white),
-                )
-              ),
-              child: TextField(
-                controller: emailController,
-                scrollPadding: EdgeInsets.only(bottom: bottomInsets +10),
-                keyboardType: TextInputType.emailAddress,
-                style: TextStyle(
-                  color: Color.fromRGBO(255, 255, 255, 1),
-                  fontSize: 24.0
-                ),
-                decoration: InputDecoration(
-                  border: InputBorder.none,
-                  enabledBorder: UnderlineInputBorder(
-                    borderSide: BorderSide(
-                        color: Colors.transparent),
-                  ),
-                  focusedBorder: UnderlineInputBorder(
-                    borderSide: BorderSide(color: Colors.transparent),
-                  ),
-                  labelText: "Email",
-                  labelStyle: TextStyle(
-                    color: Color.fromRGBO(255, 255, 255, 0.7),
-                  ),
-                ),
-              ),
-            ),
-            SizedBox(
-              height: 30.0,
-            ),
-            Container(
-              height: 62,
-              padding: const EdgeInsets.only(left: 8.0),
-              decoration: BoxDecoration(
-                  border: Border(
-                    left: BorderSide(width: 3.0, color: Colors.white),
-                  )
-              ),
-              child: TextField(
-                controller: passwordController,
-                keyboardType: TextInputType.text,
-                style: TextStyle(
-                  color: Colors.white,
-                    fontSize: 24.0
-                ),
-                obscureText: true,
-                decoration: InputDecoration(
-                  border: InputBorder.none,
-                  enabledBorder: UnderlineInputBorder(
-                    borderSide: BorderSide(
-                        color: Colors.transparent),
-                  ),
-                  labelText: "Contraseña",
-                  labelStyle: TextStyle(
-                    color: Color.fromRGBO(255, 255, 255, 0.7),
-                  ),
+  Future<void> _submit() async {
+    if (_loading) return;
+    FocusScope.of(context).unfocus();
+    if (!_validate()) return;
+    setState(() => _loading = true);
+    await _presenter.login(_emailCtrl.text.trim(), _passwordCtrl.text);
+    if (!mounted) return;
+    setState(() => _loading = false);
+  }
 
-                ),
-              ),
-            ),
-            SizedBox(
-              height: 30.0,
-            ),
-            Container(
-              alignment: Alignment.centerRight,
-              child: Text(
-                "Has olvidado la contraseña?",
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 12.0,
-                ),
-              ),
-            ),
-            SizedBox(
-              height: 42,
-            ),
-            Container(
-              width: MediaQuery.of(context).size.width*0.72,
-              child: ElevatedButton(
-                onPressed: () => _presenter.login(
-                    emailController.text, passwordController.text),
-                style: ButtonStyle(
-                    shape: MaterialStateProperty.all(RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8), // <-- Radius
-                    ),),
-                    minimumSize: MaterialStateProperty.all(Size.fromHeight(48)),
-                    backgroundColor: MaterialStateProperty.all(Color.fromRGBO(0, 189, 195, 1))),
-
-                child:Text(
-                    "Iniciar sesión",
-                    style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        color: Colors.white,
-                        fontSize: 16.0),
-                  ),
-              ),
-            ),
-            SizedBox(
-              height: 18.0,
-            ),
-            Container(
-              width: MediaQuery.of(context).size.width*0.72,
-              child: ElevatedButton(
-                onPressed: () => GlobalMethods().pushPage(context, Register()),
-                child: Text('Registrarse',style: TextStyle(
-                    color: Color.fromRGBO(0, 189, 195, 1),
-                    fontWeight: FontWeight.bold
-                ),),
-                  style: ButtonStyle(
-              shape: MaterialStateProperty.all(RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8), // <-- Radius
-      ),),
-    minimumSize: MaterialStateProperty.all(Size.fromHeight(48)),
-    backgroundColor: MaterialStateProperty.all(Colors.white))
-              ),
-            ),
-          ],
-        ),
-          ),
-          ]),
-      ),
+  void _closeAndContinueAsGuest() {
+    GlobalMethods().removePagesAndGoToNewScreen(
+      context,
+      NewHomeTabScaffold(screens: [
+        const NewHomeScreen(),
+        const ListasScreen(),
+        MapSearch(),
+        const DiscoverScreen(),
+        Login('Para ver tu perfíl debes iniciar sesión.'),
+      ]),
     );
   }
 
   @override
-  loginError() {
-  setState(() {
-    dataError = true;
-  });
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    final canDismiss = Navigator.of(context).canPop();
+
+    return Scaffold(
+      backgroundColor: AppColors.crema,
+      // Tap fuera de los textfields → cierra teclado.
+      body: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: Stack(
+        children: [
+          // Hero image with cream gradient blending into the form area.
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            height: size.height * 0.42,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                Image.asset(
+                  'assets/images/loginBg.png',
+                  fit: BoxFit.cover,
+                ),
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        AppColors.profundo.withOpacity(0.35),
+                        AppColors.profundo.withOpacity(0.15),
+                        AppColors.crema,
+                      ],
+                      stops: const [0.0, 0.55, 1.0],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SafeArea(
+            child: SingleChildScrollView(
+              padding: EdgeInsets.fromLTRB(20, 8, 20, 24 + bottomInset),
+              physics: const BouncingScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (canDismiss) ...[
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        _CircleIconButton(
+                          icon: Icons.close_rounded,
+                          onTap: _closeAndContinueAsGuest,
+                          background: Colors.white.withOpacity(0.92),
+                          foreground: AppColors.ink,
+                        ),
+                        GestureDetector(
+                          onTap: _closeAndContinueAsGuest,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 6, vertical: 10),
+                            child: Text(
+                              'Saltar',
+                              style: AppTextStyles.ui(
+                                size: 13,
+                                weight: FontWeight.w700,
+                                color: Colors.white,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 28),
+                  ] else
+                    const SizedBox(height: 12),
+                  Padding(
+                    padding: const EdgeInsets.only(right: 12),
+                    child: Text(
+                      'Hola de nuevo',
+                      style: AppTextStyles.displayHero(
+                        size: 36,
+                        color: Colors.white,
+                      ).copyWith(height: 1.05),
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    widget.mainText.isEmpty
+                        ? 'Inicia sesión para guardar tus favoritos y ver tu perfil.'
+                        : widget.mainText,
+                    style: AppTextStyles.ui(
+                      size: 14,
+                      color: Colors.white.withOpacity(0.92),
+                    ).copyWith(height: 1.35),
+                  ),
+                  const SizedBox(height: 28),
+                  _Card(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        if (_formError != null)
+                          _ErrorBanner(message: _formError!),
+                        _ModernField(
+                          controller: _emailCtrl,
+                          focusNode: _emailFocus,
+                          label: 'Email',
+                          hint: 'tu@email.com',
+                          icon: Icons.alternate_email_rounded,
+                          keyboardType: TextInputType.emailAddress,
+                          textInputAction: TextInputAction.next,
+                          autofillHints: const [AutofillHints.email],
+                          errorText: _emailError,
+                          onSubmitted: (_) =>
+                              FocusScope.of(context).requestFocus(_passwordFocus),
+                          onChanged: (_) {
+                            if (_emailError != null) {
+                              setState(() => _emailError = null);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 14),
+                        _ModernField(
+                          controller: _passwordCtrl,
+                          focusNode: _passwordFocus,
+                          label: 'Contraseña',
+                          hint: '••••••••',
+                          icon: Icons.lock_outline_rounded,
+                          obscure: !_passwordVisible,
+                          textInputAction: TextInputAction.done,
+                          autofillHints: const [AutofillHints.password],
+                          errorText: _passwordError,
+                          trailing: IconButton(
+                            splashRadius: 20,
+                            icon: Icon(
+                              _passwordVisible
+                                  ? Icons.visibility_off_rounded
+                                  : Icons.visibility_rounded,
+                              size: 20,
+                              color: AppColors.inkMuted,
+                            ),
+                            onPressed: () => setState(
+                                () => _passwordVisible = !_passwordVisible),
+                          ),
+                          onSubmitted: (_) => _submit(),
+                          onChanged: (_) {
+                            if (_passwordError != null) {
+                              setState(() => _passwordError = null);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 6),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: TextButton(
+                            onPressed: () {
+                              ScaffoldMessenger.of(context)
+                                  .showSnackBar(const SnackBar(
+                                content: Text(
+                                    'Contacta con soporte para restablecer la contraseña.'),
+                                duration: Duration(seconds: 2),
+                              ));
+                            },
+                            child: Text(
+                              '¿Has olvidado la contraseña?',
+                              style: AppTextStyles.ui(
+                                size: 12,
+                                weight: FontWeight.w600,
+                                color: AppColors.atlantico,
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        _PrimaryButton(
+                          label: 'Iniciar sesión',
+                          loading: _loading,
+                          onPressed: _submit,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        '¿Aún no tienes cuenta?',
+                        style: AppTextStyles.ui(
+                          size: 13,
+                          color: AppColors.inkSoft,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      TextButton(
+                        onPressed: () =>
+                            GlobalMethods().pushPage(context, Register()),
+                        child: Text(
+                          'Crear cuenta',
+                          style: AppTextStyles.ui(
+                            size: 13,
+                            weight: FontWeight.w800,
+                            color: AppColors.atlantico,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+        ),
+      ),
+    );
+  }
+
+  // ── LoginView ──────────────────────────────────────────────────────────
+  @override
+  loginSuccess(List<Widget> screens) {
+    if (!mounted) return;
+    GlobalMethods()
+        .removePagesAndGoToNewScreen(context, NewHomeTabScaffold(screens: screens));
+    if (widget.isModal) {
+      GlobalMethods().pushPage(context, SurveyDetails());
+    }
   }
 
   @override
-  loginSuccess(List<Widget> screens) {
-    GlobalMethods().removePagesAndGoToNewScreen(
-        context, NewHomeTabScaffold(screens: screens));
-    if(widget.isModal) {
-      GlobalMethods().pushPage(context, SurveyDetails());
+  loginError() {
+    if (!mounted) return;
+    setState(() {
+      _formError = 'Email o contraseña incorrectos.';
+      _loading = false;
+    });
+  }
+}
+
+// ── Reusable widgets ────────────────────────────────────────────────────────
+class _Card extends StatelessWidget {
+  final Widget child;
+  const _Card({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(18, 18, 18, 16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.borderCreamMd),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.ink.withOpacity(0.06),
+            blurRadius: 24,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: child,
+    );
+  }
+}
+
+class _CircleIconButton extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback onTap;
+  final Color background;
+  final Color foreground;
+  const _CircleIconButton({
+    required this.icon,
+    required this.onTap,
+    required this.background,
+    required this.foreground,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        width: 40,
+        height: 40,
+        decoration: BoxDecoration(
+          color: background,
+          shape: BoxShape.circle,
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.ink.withOpacity(0.08),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Icon(icon, size: 20, color: foreground),
+      ),
+    );
+  }
+}
+
+class _ErrorBanner extends StatelessWidget {
+  final String message;
+  const _ErrorBanner({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 14),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppColors.mojo.withOpacity(0.10),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.mojo.withOpacity(0.35)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.error_outline_rounded,
+              size: 18, color: AppColors.mojo),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: AppTextStyles.ui(
+                size: 12,
+                weight: FontWeight.w600,
+                color: AppColors.mojo,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ModernField extends StatefulWidget {
+  final TextEditingController controller;
+  final FocusNode? focusNode;
+  final String label;
+  final String hint;
+  final IconData icon;
+  final bool obscure;
+  final String? errorText;
+  final TextInputType? keyboardType;
+  final TextInputAction? textInputAction;
+  final List<String>? autofillHints;
+  final Widget? trailing;
+  final ValueChanged<String>? onSubmitted;
+  final ValueChanged<String>? onChanged;
+
+  const _ModernField({
+    required this.controller,
+    required this.label,
+    required this.hint,
+    required this.icon,
+    this.focusNode,
+    this.obscure = false,
+    this.errorText,
+    this.keyboardType,
+    this.textInputAction,
+    this.autofillHints,
+    this.trailing,
+    this.onSubmitted,
+    this.onChanged,
+  });
+
+  @override
+  State<_ModernField> createState() => _ModernFieldState();
+}
+
+class _ModernFieldState extends State<_ModernField> {
+  late final FocusNode _focus;
+  bool _ownsFocus = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.focusNode != null) {
+      _focus = widget.focusNode!;
+    } else {
+      _focus = FocusNode();
+      _ownsFocus = true;
     }
+    _focus.addListener(_onFocus);
+  }
+
+  void _onFocus() => setState(() {});
+
+  @override
+  void dispose() {
+    _focus.removeListener(_onFocus);
+    if (_ownsFocus) _focus.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasError = widget.errorText != null;
+    final focused = _focus.hasFocus;
+    final borderColor = hasError
+        ? AppColors.mojo
+        : focused
+            ? AppColors.atlantico
+            : AppColors.borderCreamMd;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 4, bottom: 6),
+          child: Text(
+            widget.label.toUpperCase(),
+            style: AppTextStyles.eyebrow(
+              size: 10,
+              color: hasError
+                  ? AppColors.mojo
+                  : focused
+                      ? AppColors.atlantico
+                      : AppColors.inkMuted,
+            ),
+          ),
+        ),
+        AnimatedContainer(
+          duration: const Duration(milliseconds: 160),
+          decoration: BoxDecoration(
+            color: AppColors.crema.withOpacity(focused ? 0.55 : 0.35),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: borderColor,
+              width: focused || hasError ? 1.5 : 1,
+            ),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            children: [
+              Icon(widget.icon, size: 18, color: AppColors.inkMuted),
+              const SizedBox(width: 10),
+              Expanded(
+                child: TextField(
+                  controller: widget.controller,
+                  focusNode: _focus,
+                  obscureText: widget.obscure,
+                  keyboardType: widget.keyboardType,
+                  textInputAction: widget.textInputAction,
+                  autofillHints: widget.autofillHints,
+                  onSubmitted: widget.onSubmitted,
+                  onChanged: widget.onChanged,
+                  cursorColor: AppColors.atlantico,
+                  style: AppTextStyles.ui(
+                    size: 15,
+                    color: AppColors.ink,
+                    weight: FontWeight.w500,
+                  ),
+                  decoration: InputDecoration(
+                    isDense: true,
+                    contentPadding: const EdgeInsets.symmetric(vertical: 16),
+                    border: InputBorder.none,
+                    hintText: widget.hint,
+                    hintStyle: AppTextStyles.ui(
+                      size: 15,
+                      color: AppColors.inkMuted,
+                    ),
+                  ),
+                ),
+              ),
+              if (widget.trailing != null) widget.trailing!,
+            ],
+          ),
+        ),
+        if (hasError)
+          Padding(
+            padding: const EdgeInsets.only(left: 4, top: 6),
+            child: Row(
+              children: [
+                const Icon(Icons.error_outline_rounded,
+                    size: 13, color: AppColors.mojo),
+                const SizedBox(width: 4),
+                Text(
+                  widget.errorText!,
+                  style: AppTextStyles.ui(
+                    size: 11,
+                    weight: FontWeight.w600,
+                    color: AppColors.mojo,
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+  final bool loading;
+
+  const _PrimaryButton({
+    required this.label,
+    required this.onPressed,
+    this.loading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 54,
+      child: ElevatedButton(
+        onPressed: loading ? null : onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.atlantico,
+          foregroundColor: Colors.white,
+          disabledBackgroundColor: AppColors.atlantico.withOpacity(0.6),
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+        child: loading
+            ? const SizedBox(
+                width: 22,
+                height: 22,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2.4,
+                  color: Colors.white,
+                ),
+              )
+            : Text(
+                label,
+                style: AppTextStyles.ui(
+                  size: 15,
+                  weight: FontWeight.w800,
+                  color: Colors.white,
+                ),
+              ),
+      ),
+    );
   }
 }
 

--- a/lib/ui/pages/login/login_presenter.dart
+++ b/lib/ui/pages/login/login_presenter.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:guachinches/data/RemoteRepository.dart';
 import 'package:guachinches/data/cubit/user/user_cubit.dart';
+import 'package:guachinches/ui/pages/discover/discover_screen.dart';
 import 'package:guachinches/ui/pages/listas/listas_screen.dart';
 import 'package:guachinches/ui/pages/map/map_search.dart';
 import 'package:guachinches/ui/pages/new_home/new_home_screen.dart';
 import 'package:guachinches/ui/pages/profile/profile_v2.dart';
-import 'package:guachinches/ui/pages/video/video.dart';
 
 class LoginPresenter{
   final RemoteRepository _remoteRepository;
@@ -23,7 +23,7 @@ class LoginPresenter{
       const NewHomeScreen(),
       const ListasScreen(),
       MapSearch(),
-      VideoScreen(index: 0),
+      const DiscoverScreen(),
       Profilev2(),
     ];
 

--- a/lib/ui/pages/map/map_search.dart
+++ b/lib/ui/pages/map/map_search.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -10,6 +11,7 @@ import 'package:guachinches/data/RemoteRepository.dart';
 import 'package:guachinches/config/app_colors.dart';
 import 'package:guachinches/config/app_text_styles.dart';
 import 'package:guachinches/config/brand_colors.dart';
+import 'package:guachinches/data/cubit/menu/menu_cubit.dart';
 import 'package:guachinches/data/cubit/restaurants/map/restaurant_map_cubit.dart';
 import 'package:guachinches/data/cubit/restaurants/map/restaurant_map_state.dart';
 import 'package:guachinches/data/model/Category.dart';
@@ -18,6 +20,7 @@ import 'package:guachinches/data/model/Types.dart';
 import 'package:guachinches/data/model/restaurant.dart';
 import 'package:guachinches/globalMethods.dart';
 import 'package:guachinches/ui/pages/map/map_search_presenter.dart';
+import 'package:guachinches/ui/pages/map/map_style.dart';
 import 'package:guachinches/ui/pages/restaurant_detail/restaurant_detail_screen.dart';
 import 'package:http/http.dart';
 import 'package:maps_launcher/maps_launcher.dart';
@@ -95,6 +98,12 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
   final TextEditingController _searchController = TextEditingController();
   Timer? _searchDebounce;
 
+  // Index del tab Mapa en NewHomeTabScaffold.
+  static const int _kMapTabIndex = 2;
+  // Defer-mount: el GoogleMap solo se monta cuando el usuario entra al tab,
+  // si no las platform views fallan al renderizar tiles.
+  bool _mapMounted = false;
+
   @override
   void initState() {
     super.initState();
@@ -108,8 +117,48 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
     presenter.getAllCategories();
 
     _driving.isDriving.addListener(_onDrivingChanged);
+    _driving.shouldSuggest.addListener(_onDriveSuggested);
     _startLiveLocation();
     _buildDotIcons();
+
+    // Si abrimos directamente esta pestaña (deep-link / initialIndex), ya
+    // estamos visibles → marcamos como montado para no mostrar placeholder.
+    final menu = context.read<MenuCubit>();
+    if (menu.state.selectedIndex == _kMapTabIndex) {
+      _mapMounted = true;
+    }
+  }
+
+  bool _suggestSheetOpen = false;
+
+  void _onDriveSuggested() {
+    if (!mounted) return;
+    if (!_driving.shouldSuggest.value) return;
+    if (_suggestSheetOpen) return;
+    _suggestSheetOpen = true;
+    HapticFeedback.mediumImpact();
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => _DriveModeSuggestionSheet(
+        onConfirm: () {
+          Navigator.of(ctx).pop();
+          _driving.confirmDrive();
+        },
+        onDismiss: () {
+          Navigator.of(ctx).pop();
+          _driving.dismissSuggestion();
+        },
+      ),
+    ).whenComplete(() {
+      _suggestSheetOpen = false;
+      // If sheet closed via swipe/back without an explicit choice, treat
+      // it as a dismissal so we don't re-prompt immediately.
+      if (_driving.shouldSuggest.value) {
+        _driving.dismissSuggestion();
+      }
+    });
   }
 
   Future<void> _buildDotIcons() async {
@@ -155,6 +204,7 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
   @override
   void dispose() {
     _driving.isDriving.removeListener(_onDrivingChanged);
+    _driving.shouldSuggest.removeListener(_onDriveSuggested);
     _driving.dispose();
     _locationSubscription?.cancel();
     _cardsPageController.dispose();
@@ -173,24 +223,45 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
     } catch (_) {
       return;
     }
-    final visible = _allRestaurants.where((r) {
+    final inBounds = _allRestaurants.where((r) {
       if (r.lat == 0.0 && r.lon == 0.0) return false;
       return bounds.contains(LatLng(r.lat, r.lon));
     }).toList();
+    final inBoundsIds = inBounds.map((r) => r.id).toSet();
 
-    visible.sort((a, b) => _distanceTo(a).compareTo(_distanceTo(b)));
+    // Stable order: keep already-shown restaurants in their existing slots
+    // (so swiping cards never reshuffles the carousel under the user's
+    // finger). Newly-visible restaurants are appended sorted by distance.
+    final preserved = _visibleRestaurants
+        .where((r) => inBoundsIds.contains(r.id))
+        .toList(growable: false);
+    final preservedIds = preserved.map((r) => r.id).toSet();
+    final newlyVisible = inBounds
+        .where((r) => !preservedIds.contains(r.id))
+        .toList()
+      ..sort((a, b) => _distanceTo(a).compareTo(_distanceTo(b)));
+
+    // First load (or after a hard reset): no stable order to preserve, so
+    // sort everything by distance from the user.
+    final List<Restaurant> visible;
+    if (preserved.isEmpty) {
+      visible = newlyVisible;
+    } else {
+      visible = [...preserved, ...newlyVisible];
+    }
 
     if (!mounted) return;
     setState(() {
       _visibleRestaurants = visible;
       // Keep selection if still visible, otherwise pick the closest visible.
       if (_selectedRestaurantId == null ||
-          !visible.any((r) => r.id == _selectedRestaurantId)) {
+          !inBoundsIds.contains(_selectedRestaurantId)) {
         _selectedRestaurantId = visible.isNotEmpty ? visible.first.id : null;
       }
     });
 
-    // Sync the PageView to the selected restaurant.
+    // Sync the PageView only if the selected card actually moved to a
+    // different index in the new list (rare with stable ordering).
     final idx = _selectedIndex();
     if (idx >= 0 &&
         _cardsPageController.hasClients &&
@@ -262,19 +333,49 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
       _animateToUser(zoom: 14.4746, tilt: 0, bearing: 0);
     } else if (_driving.isDriving.value) {
       _animateToUser(
-        zoom: 17,
-        tilt: 60,
+        zoom: 16,
+        tilt: 55,
         bearing: _lastHeading,
+        chase: true,
       );
     }
   }
 
-  Future<void> _animateToUser(
-      {double zoom = 15, double tilt = 0, double bearing = 0}) async {
+  /// Returns a point `meters` ahead of `origin` along `bearingDeg` (great-
+  /// circle). Used by the chase camera so the user marker sits near the
+  /// bottom of the viewport while the road ahead stays visible.
+  static LatLng _projectAhead(
+      LatLng origin, double bearingDeg, double meters) {
+    const earthR = 6371000.0;
+    final br = bearingDeg * math.pi / 180.0;
+    final dr = meters / earthR;
+    final lat1 = origin.latitude * math.pi / 180.0;
+    final lon1 = origin.longitude * math.pi / 180.0;
+    final lat2 = math.asin(
+      math.sin(lat1) * math.cos(dr) +
+          math.cos(lat1) * math.sin(dr) * math.cos(br),
+    );
+    final lon2 = lon1 +
+        math.atan2(
+          math.sin(br) * math.sin(dr) * math.cos(lat1),
+          math.cos(dr) - math.sin(lat1) * math.sin(lat2),
+        );
+    return LatLng(lat2 * 180.0 / math.pi, lon2 * 180.0 / math.pi);
+  }
+
+  Future<void> _animateToUser({
+    double zoom = 15,
+    double tilt = 0,
+    double bearing = 0,
+    bool chase = false,
+  }) async {
     final controller = await _controller.future;
+    final target = chase
+        ? _projectAhead(currentLocation, bearing, 240)
+        : currentLocation;
     controller.animateCamera(CameraUpdate.newCameraPosition(
       CameraPosition(
-        target: currentLocation,
+        target: target,
         zoom: zoom,
         tilt: tilt,
         bearing: bearing,
@@ -287,7 +388,12 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
     HapticFeedback.lightImpact();
     setState(() {});
     if (_driving.isDriving.value) {
-      _animateToUser(zoom: 17, tilt: 60, bearing: _lastHeading);
+      _animateToUser(
+        zoom: 16,
+        tilt: 55,
+        bearing: _lastHeading,
+        chase: true,
+      );
     } else {
       _animateToUser(zoom: 15, tilt: 0, bearing: 0);
     }
@@ -372,23 +478,27 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
   Future<BitmapDescriptor> _buildBubbleMarker(Restaurant r,
       {bool selected = false}) async {
     // Compact "rating pill" marker (TheFork-style).
-    final double scale = selected ? 3.6 : 3.0; // selected slightly bigger
-    const double pad = 10;
-    const double h = 30;
-    const double tailW = 8;
-    const double tailH = 6;
+    // Selected markers are noticeably larger and use the atlántico/blue
+    // brand color so they pop against the cream-toned map.
+    final double scale = selected ? 4.2 : 3.0;
+    final double pad = selected ? 14 : 10;
+    final double h = selected ? 40 : 30;
+    final double tailW = selected ? 12 : 8;
+    final double tailH = selected ? 9 : 6;
+    final double radius = selected ? 14 : 10;
+    final double fontSize = selected ? 16 : 13;
+    final double dotSize = selected ? 9 : 7;
+    final double dotGap = selected ? 7 : 5;
 
-    // Decide label text first so we can size to it.
     final ratingText =
         r.avgRating > 0 ? r.avgRating.toStringAsFixed(1) : 'n/d';
 
-    // Layout text to measure required width.
     final ratingPainter = TextPainter(
       text: TextSpan(
         text: ratingText,
-        style: const TextStyle(
+        style: TextStyle(
           color: Colors.white,
-          fontSize: 13,
+          fontSize: fontSize,
           fontFamily: 'SF Pro Display',
           fontWeight: FontWeight.w800,
           letterSpacing: 0.2,
@@ -398,61 +508,94 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
     );
     ratingPainter.layout();
 
-    const double dotSize = 7;
-    const double dotGap = 5;
     final double w = pad + dotSize + dotGap + ratingPainter.width + pad;
-    final double totalW = w;
-    final double totalH = h + tailH;
+    // Halo around selected marker so it stands out on the map. Padding only
+    // on top + sides (not below) so the tail tip stays at the bitmap bottom
+    // and the marker anchor (0.5, 1.0) lands on the restaurant coords.
+    final double haloPad = selected ? 6 : 0;
+    final double totalW = w + haloPad * 2;
+    final double totalH = h + tailH + haloPad;
+    final double originX = haloPad;
+    final double originY = haloPad;
 
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
     canvas.scale(scale, scale);
 
-    final bgPaint = Paint()..color = const Color(0xFF1B1D22);
+    final bgPaint = Paint()
+      ..color = selected
+          ? GlobalMethods.blueColor
+          : const Color(0xFF1B1D22);
     final pillRRect = RRect.fromRectAndRadius(
-      Rect.fromLTWH(0, 0, w, h),
-      const Radius.circular(10),
+      Rect.fromLTWH(originX, originY, w, h),
+      Radius.circular(radius),
     );
 
-    // Drop shadow
+    // Halo (outer soft ring, selected only).
+    if (selected) {
+      final haloRRect = RRect.fromRectAndRadius(
+        Rect.fromLTWH(
+          originX - haloPad,
+          originY - haloPad,
+          w + haloPad * 2,
+          h + haloPad * 2,
+        ),
+        Radius.circular(radius + haloPad),
+      );
+      canvas.drawRRect(
+        haloRRect,
+        Paint()
+          ..color = GlobalMethods.blueColor.withOpacity(0.22)
+          ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 6),
+      );
+    }
+
+    // Drop shadow.
     canvas.drawRRect(
-      pillRRect.shift(const Offset(0, 2)),
+      pillRRect.shift(Offset(0, selected ? 3 : 2)),
       Paint()
-        ..color = const Color(0x55000000)
-        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 4),
+        ..color = Color.fromRGBO(0, 0, 0, selected ? 0.45 : 0.33)
+        ..maskFilter = MaskFilter.blur(
+            BlurStyle.normal, selected ? 6 : 4),
     );
     canvas.drawRRect(pillRRect, bgPaint);
 
-    // Border (highlighted when selected)
+    // White outline for selected (lifts pill from blurred shadow); subtle
+    // dark border for unselected.
     final borderPaint = Paint()
       ..color = selected
-          ? GlobalMethods.blueColor
+          ? Colors.white
           : Colors.white.withOpacity(0.12)
       ..style = PaintingStyle.stroke
-      ..strokeWidth = selected ? 2 : 1;
+      ..strokeWidth = selected ? 2.5 : 1;
     canvas.drawRRect(pillRRect, borderPaint);
 
-    // Status dot (open/closed)
+    // Status dot (open/closed).
     final dotColor = r.open
         ? const Color.fromRGBO(149, 220, 0, 1)
         : const Color.fromRGBO(226, 120, 120, 1);
     canvas.drawCircle(
-      Offset(pad + dotSize / 2, h / 2),
+      Offset(originX + pad + dotSize / 2, originY + h / 2),
       dotSize / 2,
       Paint()..color = dotColor,
     );
 
-    // Rating text
+    // Rating text.
     ratingPainter.paint(
       canvas,
-      Offset(pad + dotSize + dotGap, (h - ratingPainter.height) / 2),
+      Offset(
+        originX + pad + dotSize + dotGap,
+        originY + (h - ratingPainter.height) / 2,
+      ),
     );
 
-    // Tail (downward triangle)
+    // Tail (downward triangle).
+    final tailCenterX = originX + w / 2;
+    final tailTopY = originY + h - 0.5;
     final tailPath = Path()
-      ..moveTo(w / 2 - tailW / 2, h - 0.5)
-      ..lineTo(w / 2 + tailW / 2, h - 0.5)
-      ..lineTo(w / 2, h + tailH)
+      ..moveTo(tailCenterX - tailW / 2, tailTopY)
+      ..lineTo(tailCenterX + tailW / 2, tailTopY)
+      ..lineTo(tailCenterX, originY + h + tailH)
       ..close();
     canvas.drawPath(tailPath, bgPaint);
 
@@ -520,6 +663,44 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
   // ── Build ──────────────────────────────────────────────────────────────
   @override
   Widget build(BuildContext context) {
+    return BlocListener<MenuCubit, MenuState>(
+      listenWhen: (prev, curr) =>
+          !_mapMounted && curr.selectedIndex == _kMapTabIndex,
+      listener: (_, __) {
+        // Pequeño delay: el IndexedStack acaba de hacer visible este hijo,
+        // damos un frame para que la Vista esté lista antes de montar la
+        // platform view de GoogleMap. Evita tiles en blanco.
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted || _mapMounted) return;
+          setState(() => _mapMounted = true);
+        });
+      },
+      child: _buildScaffold(context),
+    );
+  }
+
+  Widget _buildScaffold(BuildContext context) {
+    if (!_mapMounted) {
+      return Scaffold(
+        backgroundColor: context.brand.base,
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const CircularProgressIndicator(
+                strokeWidth: 2,
+                color: AppColors.atlanticoClaro,
+              ),
+              const SizedBox(height: 14),
+              Text(
+                'Preparando el mapa…',
+                style: AppTextStyles.muted(size: 12),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
     final isDriving = _driving.isDriving.value;
 
     return Scaffold(
@@ -544,8 +725,6 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
           }
 
           final sorted = _sortedByDistance(restaurants);
-          final nearest = sorted.isNotEmpty ? sorted.first : null;
-          final others = sorted.length > 1 ? sorted.sublist(1) : <Restaurant>[];
 
           return Stack(
             fit: StackFit.expand,
@@ -553,6 +732,7 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
               Positioned.fill(
                 child: GoogleMap(
                   mapType: MapType.normal,
+                  style: kMapStyleLight,
                   myLocationEnabled: true,
                   myLocationButtonEnabled: false,
                   compassEnabled: false,
@@ -578,38 +758,24 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
               ),
 
               // ── Header (search + filter chips) ─────────────────────────
-              if (!isDriving)
-                Positioned(
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  child: _MapHeader(
-                    categories: categories,
-                    selectedCategoryId: _quickCategoryId,
-                    openActive: _quickOpen,
-                    municipalityLabel: _municipalityLabel,
-                    searchController: _searchController,
-                    onSearchChanged: _onSearchChanged,
-                    onClearSearch: _clearSearch,
-                    onToggleOpen: _toggleOpenFilter,
-                    onToggleCategory: _toggleCategory,
-                  ),
-                ),
-
-              // ── Drive-mode banner ──────────────────────────────────────
+              // In drive mode the search bar is hidden (distraction) and
+              // we show a compact chip row at the top with a "Salir" pill.
               Positioned(
                 top: 0,
                 left: 0,
                 right: 0,
-                child: AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 250),
-                  child: isDriving
-                      ? _DriveModeBanner(
-                          key: const ValueKey('drive-banner'),
-                          onExit: _exitDriveMode,
-                        )
-                      : const SizedBox.shrink(
-                          key: ValueKey('drive-banner-empty')),
+                child: _MapHeader(
+                  categories: categories,
+                  selectedCategoryId: _quickCategoryId,
+                  openActive: _quickOpen,
+                  municipalityLabel: _municipalityLabel,
+                  searchController: _searchController,
+                  onSearchChanged: _onSearchChanged,
+                  onClearSearch: _clearSearch,
+                  onToggleOpen: _toggleOpenFilter,
+                  onToggleCategory: _toggleCategory,
+                  driveMode: isDriving,
+                  onExitDrive: _exitDriveMode,
                 ),
               ),
 
@@ -621,14 +787,41 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
                   heroTag: 'centerOnUser',
                   backgroundColor: context.brand.surface,
                   onPressed: () => _animateToUser(
-                    zoom: isDriving ? 17 : 15,
-                    tilt: isDriving ? 60 : 0,
+                    zoom: isDriving ? 16 : 15,
+                    tilt: isDriving ? 55 : 0,
                     bearing: isDriving ? _lastHeading : 0,
+                    chase: isDriving,
                   ),
                   child: Icon(Icons.my_location,
                       color: context.brand.textPrimary, size: 20),
                 ),
               ),
+
+              // ── "Activar modo coche" shortcut ──────────────────────────
+              // Shown when we detect movement at drive speed but the user is
+              // not in drive mode (dismissed the suggestion or exited by
+              // accident). Tap to enter drive mode immediately.
+              if (!isDriving)
+                Positioned(
+                  bottom: 142,
+                  left: 16,
+                  child: ValueListenableBuilder<double>(
+                    valueListenable: _driving.currentSpeed,
+                    builder: (context, speed, _) {
+                      final visible = speed > _kEnterDriveSpeed;
+                      return AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 220),
+                        child: visible
+                            ? _EnterDrivePill(
+                                key: const ValueKey('enter-drive'),
+                                onTap: () => _driving.confirmDrive(),
+                              )
+                            : const SizedBox.shrink(
+                                key: ValueKey('enter-drive-empty')),
+                      );
+                    },
+                  ),
+                ),
 
               // ── Bottom: drive-mode pill list OR nearby carousel ────────
               if (isDriving)
@@ -637,8 +830,7 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
                   right: 0,
                   bottom: 0,
                   child: _DriveNearbyStrip(
-                    nearest: nearest,
-                    others: others.take(8).toList(),
+                    nearby: sorted.take(10).toList(),
                     distanceTo: _distanceTo,
                   ),
                 )
@@ -727,30 +919,84 @@ class MapSearchState extends State<MapSearch> implements MapSearchView {
 class _DrivingDetector {
   final List<double> _samples = [];
   final ValueNotifier<bool> isDriving = ValueNotifier<bool>(false);
+  // Fires when we detect driving but haven't asked the user yet. The UI
+  // listens and shows a confirmation sheet.
+  final ValueNotifier<bool> shouldSuggest = ValueNotifier<bool>(false);
+  // Live median speed (m/s). Used by the UI to show a "Activar modo coche"
+  // shortcut while moving but outside drive mode (e.g. after the user
+  // dismissed the suggestion or exited drive mode by mistake).
+  final ValueNotifier<double> currentSpeed = ValueNotifier<double>(0);
+  Position? _lastPos;
+  DateTime? _suppressUntil;
 
   void onPosition(Position p) {
-    final speed = p.speed.isFinite && p.speed >= 0 ? p.speed : 0.0;
+    // iOS Simulator's `simctl location start` reports CLLocation.speed=0 (or -1)
+    // even while the position is moving, so we compute speed from the
+    // distance/time delta between successive points and keep whichever value
+    // is higher. Real devices keep using the OS-provided speed.
+    double computed = 0;
+    if (_lastPos != null) {
+      final dtMs = p.timestamp
+          .difference(_lastPos!.timestamp)
+          .inMilliseconds;
+      if (dtMs > 0) {
+        final meters = Geolocator.distanceBetween(
+          _lastPos!.latitude,
+          _lastPos!.longitude,
+          p.latitude,
+          p.longitude,
+        );
+        computed = meters / (dtMs / 1000.0);
+      }
+    }
+    final raw = p.speed.isFinite && p.speed > 0 ? p.speed : 0.0;
+    final speed = raw > computed ? raw : computed;
+    _lastPos = p;
+
     _samples.add(speed);
     if (_samples.length > _kDriveSampleWindow) {
       _samples.removeAt(0);
     }
     final med = _median(_samples);
-    if (!isDriving.value &&
-        _samples.length >= _kDriveMinSamplesToEnter &&
-        med > _kEnterDriveSpeed) {
-      isDriving.value = true;
-    } else if (isDriving.value && med < _kExitDriveSpeed) {
-      isDriving.value = false;
+    currentSpeed.value = med;
+
+    if (isDriving.value) {
+      if (med < _kExitDriveSpeed) isDriving.value = false;
+      return;
     }
+    if (shouldSuggest.value) return; // already asking
+    final cooldownActive = _suppressUntil != null &&
+        DateTime.now().isBefore(_suppressUntil!);
+    if (cooldownActive) return;
+    if (_samples.length >= _kDriveMinSamplesToEnter &&
+        med > _kEnterDriveSpeed) {
+      shouldSuggest.value = true;
+    }
+  }
+
+  void confirmDrive() {
+    shouldSuggest.value = false;
+    isDriving.value = true;
+  }
+
+  void dismissSuggestion(
+      {Duration cooldown = const Duration(minutes: 5)}) {
+    shouldSuggest.value = false;
+    _suppressUntil = DateTime.now().add(cooldown);
   }
 
   void forceExit() {
     _samples.clear();
+    _lastPos = null;
+    _suppressUntil = DateTime.now().add(const Duration(minutes: 5));
     isDriving.value = false;
+    shouldSuggest.value = false;
   }
 
   void dispose() {
     isDriving.dispose();
+    shouldSuggest.dispose();
+    currentSpeed.dispose();
   }
 
   static double _median(List<double> values) {
@@ -762,85 +1008,136 @@ class _DrivingDetector {
   }
 }
 
-// ── Drive-mode banner ───────────────────────────────────────────────────
-class _DriveModeBanner extends StatelessWidget {
-  final VoidCallback onExit;
-  const _DriveModeBanner({Key? key, required this.onExit}) : super(key: key);
+// ── Drive-mode suggestion sheet ─────────────────────────────────────────
+class _DriveModeSuggestionSheet extends StatelessWidget {
+  final VoidCallback onConfirm;
+  final VoidCallback onDismiss;
+  const _DriveModeSuggestionSheet({
+    Key? key,
+    required this.onConfirm,
+    required this.onDismiss,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final brand = context.brand;
     return SafeArea(
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
-        child: Material(
-          color: Colors.transparent,
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-            decoration: BoxDecoration(
-              color: GlobalMethods.blueColor,
-              borderRadius: BorderRadius.circular(16),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black.withOpacity(0.25),
-                  blurRadius: 10,
-                  offset: const Offset(0, 4),
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: Container(
+          decoration: BoxDecoration(
+            color: brand.surface,
+            borderRadius: BorderRadius.circular(28),
+            border: Border.all(color: brand.border),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.22),
+                blurRadius: 24,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          padding: const EdgeInsets.fromLTRB(20, 22, 20, 18),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  color: GlobalMethods.blueColor.withOpacity(0.14),
+                  shape: BoxShape.circle,
                 ),
-              ],
-            ),
-            child: Row(
-              children: [
-                const Icon(Icons.directions_car_filled,
-                    color: Colors.white, size: 22),
-                const SizedBox(width: 10),
-                const Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Modo coche',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontFamily: 'SF Pro Display',
-                          fontSize: 14,
-                          fontWeight: FontWeight.w700,
+                child: Icon(
+                  Icons.directions_car_filled,
+                  color: GlobalMethods.blueColor,
+                  size: 28,
+                ),
+              ),
+              const SizedBox(height: 14),
+              Text(
+                '¿Vas en el coche?',
+                style: TextStyle(
+                  color: brand.textPrimary,
+                  fontFamily: 'SF Pro Display',
+                  fontSize: 19,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                'Hemos notado que te mueves a buena velocidad. ¿Activamos el modo coche para mostrarte los restaurantes mientras conduces?',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: brand.textSecondary,
+                  fontFamily: 'SF Pro Display',
+                  fontSize: 13,
+                  height: 1.4,
+                ),
+              ),
+              const SizedBox(height: 20),
+              Row(
+                children: [
+                  Expanded(
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: onDismiss,
+                      child: Container(
+                        height: 50,
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          color: Colors.transparent,
+                          borderRadius: BorderRadius.circular(16),
+                          border: Border.all(
+                              color: brand.borderStrong, width: 1.2),
+                        ),
+                        child: Text(
+                          'Ahora no',
+                          style: TextStyle(
+                            color: brand.textPrimary,
+                            fontFamily: 'SF Pro Display',
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                          ),
                         ),
                       ),
-                      SizedBox(height: 2),
-                      Text(
-                        'Hemos detectado que vas en el coche. Te mostramos los restaurantes mientras conduces.',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontFamily: 'SF Pro Display',
-                          fontSize: 12,
-                          height: 1.25,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: onConfirm,
+                      child: Container(
+                        height: 50,
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          color: GlobalMethods.blueColor,
+                          borderRadius: BorderRadius.circular(16),
+                          boxShadow: [
+                            BoxShadow(
+                              color:
+                                  GlobalMethods.blueColor.withOpacity(0.38),
+                              blurRadius: 14,
+                              offset: const Offset(0, 5),
+                            ),
+                          ],
+                        ),
+                        child: const Text(
+                          'Sí, activar',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontFamily: 'SF Pro Display',
+                            fontSize: 14,
+                            fontWeight: FontWeight.w700,
+                          ),
                         ),
                       ),
-                    ],
-                  ),
-                ),
-                const SizedBox(width: 8),
-                GestureDetector(
-                  onTap: onExit,
-                  child: Container(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                    decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(0.18),
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                    child: const Text(
-                      'Salir',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontFamily: 'SF Pro Display',
-                        fontSize: 12,
-                        fontWeight: FontWeight.w600,
-                      ),
                     ),
                   ),
-                ),
-              ],
-            ),
+                ],
+              ),
+            ],
           ),
         ),
       ),
@@ -849,20 +1146,58 @@ class _DriveModeBanner extends StatelessWidget {
 }
 
 // ── Drive-mode bottom strip (compact, large-touch) ──────────────────────
-class _DriveNearbyStrip extends StatelessWidget {
-  final Restaurant? nearest;
-  final List<Restaurant> others;
+class _DriveNearbyStrip extends StatefulWidget {
+  final List<Restaurant> nearby; // sorted by distance, nearest first
   final double Function(Restaurant) distanceTo;
 
   const _DriveNearbyStrip({
     Key? key,
-    required this.nearest,
-    required this.others,
+    required this.nearby,
     required this.distanceTo,
   }) : super(key: key);
 
   @override
+  State<_DriveNearbyStrip> createState() => _DriveNearbyStripState();
+}
+
+class _DriveNearbyStripState extends State<_DriveNearbyStrip> {
+  final PageController _pc = PageController();
+  final ScrollController _pillsScroll = ScrollController();
+  int _index = 0;
+
+  @override
+  void didUpdateWidget(covariant _DriveNearbyStrip old) {
+    super.didUpdateWidget(old);
+    if (_index >= widget.nearby.length) {
+      _index = widget.nearby.isEmpty ? 0 : widget.nearby.length - 1;
+      if (_pc.hasClients) {
+        _pc.jumpToPage(_index);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _pc.dispose();
+    _pillsScroll.dispose();
+    super.dispose();
+  }
+
+  void _go(int i) {
+    if (i < 0 || i >= widget.nearby.length) return;
+    _pc.animateToPage(
+      i,
+      duration: const Duration(milliseconds: 240),
+      curve: Curves.easeOut,
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final list = widget.nearby;
+    if (list.isEmpty) return const SizedBox.shrink();
+    final clamped = _index.clamp(0, list.length - 1);
+
     return Container(
       padding: const EdgeInsets.fromLTRB(12, 14, 12, 24),
       decoration: BoxDecoration(
@@ -878,19 +1213,37 @@ class _DriveNearbyStrip extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (nearest != null) _DriveNearestCard(restaurant: nearest!, distanceMeters: distanceTo(nearest!)),
-          if (others.isNotEmpty) ...[
+          // Full-width swipeable main card. Paging: swipe horizontally OR
+          // tap a pill below.
+          SizedBox(
+            height: 116,
+            child: PageView.builder(
+              controller: _pc,
+              onPageChanged: (i) => setState(() => _index = i),
+              itemCount: list.length,
+              itemBuilder: (_, i) => _DriveNearestCard(
+                restaurant: list[i],
+                distanceMeters: widget.distanceTo(list[i]),
+                index: i,
+                total: list.length,
+              ),
+            ),
+          ),
+          if (list.length > 1) ...[
             const SizedBox(height: 10),
             SizedBox(
               height: 44,
               child: ListView.separated(
+                controller: _pillsScroll,
                 scrollDirection: Axis.horizontal,
                 itemBuilder: (_, i) => _DrivePill(
-                  restaurant: others[i],
-                  distanceMeters: distanceTo(others[i]),
+                  restaurant: list[i],
+                  distanceMeters: widget.distanceTo(list[i]),
+                  active: i == clamped,
+                  onTap: () => _go(i),
                 ),
                 separatorBuilder: (_, __) => const SizedBox(width: 8),
-                itemCount: others.length,
+                itemCount: list.length,
               ),
             ),
           ],
@@ -903,13 +1256,22 @@ class _DriveNearbyStrip extends StatelessWidget {
 class _DriveNearestCard extends StatelessWidget {
   final Restaurant restaurant;
   final double distanceMeters;
-  const _DriveNearestCard(
-      {Key? key, required this.restaurant, required this.distanceMeters})
-      : super(key: key);
+  final int index;
+  final int total;
+  const _DriveNearestCard({
+    Key? key,
+    required this.restaurant,
+    required this.distanceMeters,
+    required this.index,
+    required this.total,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final label = index == 0 ? 'MÁS CERCANO' : '${index + 1} DE $total';
+    final status = _statusFor(restaurant, distanceMeters);
     return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 2),
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
       decoration: BoxDecoration(
         color: GlobalMethods.bgColor,
@@ -928,9 +1290,10 @@ class _DriveNearestCard extends StatelessWidget {
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Text(
-                  'MÁS CERCANO',
+                  label,
                   style: TextStyle(
                     color: GlobalMethods.blueColor,
                     fontFamily: 'SF Pro Display',
@@ -953,11 +1316,11 @@ class _DriveNearestCard extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  '${restaurant.open ? "Abierto" : "Cerrado"} · ${_fmtDistance(distanceMeters)} · ${_fmtDriveMinutes(distanceMeters)}',
+                  '${status.label} · ${_fmtDistance(distanceMeters)} · ${_fmtDriveMinutes(distanceMeters)}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                   style: TextStyle(
-                    color: restaurant.open
-                        ? const Color.fromRGBO(149, 220, 0, 1)
-                        : const Color.fromRGBO(226, 120, 120, 1),
+                    color: status.color,
                     fontFamily: 'SF Pro Display',
                     fontSize: 13,
                     fontWeight: FontWeight.w600,
@@ -977,63 +1340,111 @@ class _DriveNearestCard extends StatelessWidget {
 class _DrivePill extends StatelessWidget {
   final Restaurant restaurant;
   final double distanceMeters;
-  const _DrivePill(
-      {Key? key, required this.restaurant, required this.distanceMeters})
-      : super(key: key);
+  final bool active;
+  final VoidCallback onTap;
+  const _DrivePill({
+    Key? key,
+    required this.restaurant,
+    required this.distanceMeters,
+    required this.active,
+    required this.onTap,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () => Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (_) => RestaurantDetailScreen(id: restaurant.id),
-        ),
-      ),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 14),
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: const Color(0xFF2A2D36),
-          borderRadius: BorderRadius.circular(22),
-          border: Border.all(color: Colors.white10),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              width: 10,
-              height: 10,
-              decoration: BoxDecoration(
-                color: _dotColorForRestaurant(restaurant),
-                shape: BoxShape.circle,
-              ),
+    final status = _statusFor(restaurant, distanceMeters);
+    final unreachable = status.color == _kStatusUrgent;
+    final closingSoon = status.color == _kStatusWarning;
+    // Trailing label: distance, but swap to time-to-close when urgent or
+    // soon so the user gets the most useful info at a glance.
+    final close = _closingTimeNow(restaurant);
+    String trailing;
+    if ((unreachable || closingSoon) && close != null) {
+      trailing = 'cierra ${_fmtClock(close)}';
+    } else {
+      trailing = _fmtDistance(distanceMeters);
+    }
+    return Opacity(
+      opacity: unreachable ? 0.55 : 1.0,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+          padding: const EdgeInsets.symmetric(horizontal: 14),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: active
+                ? GlobalMethods.blueColor
+                : const Color(0xFF2A2D36),
+            borderRadius: BorderRadius.circular(22),
+            border: Border.all(
+              color: active
+                  ? GlobalMethods.blueColor
+                  : (closingSoon || unreachable)
+                      ? status.color.withOpacity(0.6)
+                      : Colors.white10,
+              width: (closingSoon || unreachable) && !active ? 1.4 : 1,
             ),
-            const SizedBox(width: 10),
-            ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 140),
-              child: Text(
-                restaurant.nombre.toUpperCase(),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontFamily: 'SF Pro Display',
-                  fontSize: 12,
-                  fontWeight: FontWeight.w700,
-                  letterSpacing: 0.4,
+            boxShadow: active
+                ? [
+                    BoxShadow(
+                      color: GlobalMethods.blueColor.withOpacity(0.32),
+                      blurRadius: 10,
+                      offset: const Offset(0, 3),
+                    ),
+                  ]
+                : const [],
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 10,
+                height: 10,
+                decoration: BoxDecoration(
+                  color: status.color,
+                  shape: BoxShape.circle,
                 ),
               ),
-            ),
-            const SizedBox(width: 10),
-            Text(
-              _fmtDistance(distanceMeters),
-              style: const TextStyle(
-                color: Colors.white60,
-                fontFamily: 'SF Pro Display',
-                fontSize: 12,
+              const SizedBox(width: 10),
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 140),
+                child: Text(
+                  restaurant.nombre.toUpperCase(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontFamily: 'SF Pro Display',
+                    fontSize: 12,
+                    fontWeight: active ? FontWeight.w800 : FontWeight.w700,
+                    letterSpacing: 0.4,
+                    decoration: unreachable
+                        ? TextDecoration.lineThrough
+                        : TextDecoration.none,
+                  ),
+                ),
               ),
-            ),
-          ],
+              const SizedBox(width: 10),
+              Text(
+                trailing,
+                style: TextStyle(
+                  color: active
+                      ? Colors.white
+                      : (closingSoon || unreachable)
+                          ? status.color
+                          : Colors.white60,
+                  fontFamily: 'SF Pro Display',
+                  fontSize: 12,
+                  fontWeight: (closingSoon || unreachable)
+                      ? FontWeight.w700
+                      : FontWeight.w400,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -1247,7 +1658,11 @@ class _FloatingMapCard extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 6),
-                  _StatusLine(restaurant: r, brand: brand),
+                  _StatusLine(
+                    restaurant: r,
+                    brand: brand,
+                    distanceMeters: distanceMeters,
+                  ),
                 ],
               ),
             ),
@@ -1301,16 +1716,21 @@ class _FloatingMapCard extends StatelessWidget {
   }
 }
 
-/// Línea de estado: "● Cerrado · Candelaria · 12-22€"
+/// Línea de estado: "● Abierto hasta 22:30 · Candelaria · 12-22€"
 class _StatusLine extends StatelessWidget {
   final Restaurant restaurant;
   final BrandColors brand;
-  const _StatusLine({required this.restaurant, required this.brand});
+  final double distanceMeters;
+  const _StatusLine({
+    required this.restaurant,
+    required this.brand,
+    required this.distanceMeters,
+  });
 
   @override
   Widget build(BuildContext context) {
     final r = restaurant;
-    final statusColor = r.open ? AppColors.laurisilva : AppColors.mojo;
+    final status = _statusFor(r, distanceMeters);
     final priceLabel = (r.minPrice != null && r.maxPrice != null)
         ? '${r.minPrice}–${r.maxPrice}€'
         : null;
@@ -1339,17 +1759,21 @@ class _StatusLine extends StatelessWidget {
             width: 6,
             height: 6,
             decoration: BoxDecoration(
-              color: statusColor,
+              color: status.color,
               shape: BoxShape.circle,
             ),
           ),
           const SizedBox(width: 5),
-          Text(
-            r.open ? 'Abierto' : 'Cerrado',
-            style: AppTextStyles.ui(
-              size: 11,
-              weight: FontWeight.w700,
-              color: statusColor,
+          Flexible(
+            child: Text(
+              status.label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTextStyles.ui(
+                size: 11,
+                weight: FontWeight.w700,
+                color: status.color,
+              ),
             ),
           ),
           if (r.municipio.isNotEmpty) ...[
@@ -1432,20 +1856,85 @@ String _fmtDriveMinutes(double meters) {
   return '$mins min';
 }
 
-Color _dotColorForRestaurant(Restaurant r) {
-  // Stable color from id hash so the dot row reads as a varied palette
-  // similar to the screenshot (orange, yellow, green).
-  const palette = [
-    Color(0xFFE49B4F), // orange
-    Color(0xFFE7C34A), // yellow
-    Color(0xFF6FCF97), // green
-    Color(0xFFE2787B), // salmon
-    Color(0xFF56C7E0), // teal
-    Color(0xFFB388FF), // violet
-  ];
-  if (r.id.isEmpty) return palette[0];
-  final idx = r.id.codeUnits.fold<int>(0, (a, b) => a + b) % palette.length;
-  return palette[idx];
+int _etaMinutes(double meters) {
+  if (!meters.isFinite) return 0;
+  return (meters / 1000).ceil();
+}
+
+/// Parses `Restaurant.googleHorarios` (multi-line "Lunes: 09:00–22:30"
+/// strings) and returns the closing time of the slot the restaurant is in
+/// right now. Null if the place is closed, has no schedule, or is 24h.
+DateTime? _closingTimeNow(Restaurant r) {
+  final raw = r.googleHorarios;
+  if (raw.isEmpty) return null;
+  final lower = raw.toLowerCase();
+  if (lower == 'cerrado' || lower == 'sin horario') return null;
+  final lines = raw.split('\n');
+  final weekday = DateTime.now().toUtc().weekday - 1;
+  if (weekday < 0 || weekday >= lines.length) return null;
+  final colonIdx = lines[weekday].indexOf(': ');
+  if (colonIdx < 0) return null;
+  final hours = lines[weekday].substring(colonIdx + 2).trim();
+  final hoursLower = hours.toLowerCase();
+  if (hoursLower == 'cerrado') return null;
+  if (hoursLower.contains('24 horas')) return null;
+  final now = DateTime.now();
+  for (final range in hours.split(', ')) {
+    final hh = range.split('–');
+    if (hh.length < 2) continue;
+    final s = hh[0].split(':');
+    final e = hh[1].split(':');
+    if (s.length < 2 || e.length < 2) continue;
+    final start = DateTime(now.year, now.month, now.day,
+        int.tryParse(s[0]) ?? 0, int.tryParse(s[1]) ?? 0);
+    var end = DateTime(now.year, now.month, now.day,
+        int.tryParse(e[0]) ?? 0, int.tryParse(e[1]) ?? 0);
+    // Range crosses midnight (e.g. 19:00–01:00).
+    if (end.isBefore(start)) {
+      end = end.add(const Duration(days: 1));
+    }
+    if (now.isAfter(start) && now.isBefore(end)) return end;
+  }
+  return null;
+}
+
+String _fmtClock(DateTime dt) =>
+    '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
+
+class _RestaurantStatus {
+  final String label;
+  final Color color;
+  const _RestaurantStatus(this.label, this.color);
+}
+
+const Color _kStatusOpen = Color.fromRGBO(149, 220, 0, 1);
+const Color _kStatusClosed = Color.fromRGBO(226, 120, 120, 1);
+const Color _kStatusWarning = Color.fromRGBO(245, 183, 0, 1); // sol
+const Color _kStatusUrgent = Color.fromRGBO(232, 82, 26, 1); // mojo
+
+/// Combines open/closed + closing time + ETA into a single status descriptor.
+/// "Cierra pronto" if the slot ends in <45 min. "Estará cerrado al llegar"
+/// when ETA at ~60 km/h doesn't fit before close (or <10 min remaining).
+_RestaurantStatus _statusFor(Restaurant r, double distanceMeters) {
+  if (!r.open) {
+    return const _RestaurantStatus('Cerrado', _kStatusClosed);
+  }
+  final close = _closingTimeNow(r);
+  if (close == null) {
+    return const _RestaurantStatus('Abierto', _kStatusOpen);
+  }
+  final closesIn = close.difference(DateTime.now()).inMinutes;
+  final eta = _etaMinutes(distanceMeters);
+  final hhmm = _fmtClock(close);
+
+  if (closesIn < 10 || closesIn <= eta) {
+    return _RestaurantStatus(
+        'Estará cerrado al llegar · cierra $hhmm', _kStatusUrgent);
+  }
+  if (closesIn < 45) {
+    return _RestaurantStatus('Cierra pronto · $hhmm', _kStatusWarning);
+  }
+  return _RestaurantStatus('Abierto hasta $hhmm', _kStatusOpen);
 }
 
 // ── Header (search + chips) widget ──────────────────────────────────────
@@ -1459,6 +1948,8 @@ class _MapHeader extends StatelessWidget {
   final VoidCallback onClearSearch;
   final VoidCallback onToggleOpen;
   final ValueChanged<String> onToggleCategory;
+  final bool driveMode;
+  final VoidCallback onExitDrive;
 
   const _MapHeader({
     Key? key,
@@ -1471,6 +1962,8 @@ class _MapHeader extends StatelessWidget {
     required this.onClearSearch,
     required this.onToggleOpen,
     required this.onToggleCategory,
+    this.driveMode = false,
+    required this.onExitDrive,
   }) : super(key: key);
 
   @override
@@ -1485,7 +1978,8 @@ class _MapHeader extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Search bar (live filter) with municipality chip on the right.
-            Container(
+            // Hidden in drive mode to avoid distracting input.
+            if (!driveMode) Container(
               height: 52,
               padding: const EdgeInsets.symmetric(horizontal: 14),
               decoration: BoxDecoration(
@@ -1567,18 +2061,25 @@ class _MapHeader extends StatelessWidget {
                 ],
               ),
             ),
-            const SizedBox(height: 12),
-            // Quick filter pills row.
+            if (!driveMode) const SizedBox(height: 12),
+            // Quick filter pills row. In drive mode it sits at the very top
+            // (no search bar above) and is prefixed by a "Salir modo coche"
+            // pill so the user can leave drive mode without hunting for it.
             SizedBox(
-              height: 36,
+              height: driveMode ? 44 : 36,
               child: ListView(
                 scrollDirection: Axis.horizontal,
                 physics: const BouncingScrollPhysics(),
                 children: [
+                  if (driveMode) ...[
+                    _DriveExitPill(onTap: onExitDrive),
+                    const SizedBox(width: 8),
+                  ],
                   _QuickPill(
                     label: 'ABIERTO AHORA',
                     active: openActive,
                     onTap: onToggleOpen,
+                    big: driveMode,
                   ),
                   for (final c in categories.take(8)) ...[
                     const SizedBox(width: 8),
@@ -1586,9 +2087,108 @@ class _MapHeader extends StatelessWidget {
                       label: c.nombre.toUpperCase(),
                       active: selectedCategoryId == c.id,
                       onTap: () => onToggleCategory(c.id),
+                      big: driveMode,
                     ),
                   ],
                 ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EnterDrivePill extends StatelessWidget {
+  final VoidCallback onTap;
+  const _EnterDrivePill({Key? key, required this.onTap}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        height: 42,
+        padding: const EdgeInsets.symmetric(horizontal: 14),
+        decoration: BoxDecoration(
+          color: GlobalMethods.blueColor,
+          borderRadius: BorderRadius.circular(22),
+          boxShadow: [
+            BoxShadow(
+              color: GlobalMethods.blueColor.withOpacity(0.42),
+              blurRadius: 14,
+              offset: const Offset(0, 4),
+            ),
+            BoxShadow(
+              color: Colors.black.withOpacity(0.18),
+              blurRadius: 6,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.directions_car_filled,
+                color: Colors.white, size: 18),
+            SizedBox(width: 8),
+            Text(
+              'MODO COCHE',
+              style: TextStyle(
+                color: Colors.white,
+                fontFamily: 'SF Pro Display',
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+                letterSpacing: 0.7,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DriveExitPill extends StatelessWidget {
+  final VoidCallback onTap;
+  const _DriveExitPill({Key? key, required this.onTap}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        height: 44,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: GlobalMethods.blueColor,
+          borderRadius: BorderRadius.circular(22),
+          boxShadow: [
+            BoxShadow(
+              color: GlobalMethods.blueColor.withOpacity(0.35),
+              blurRadius: 10,
+              offset: const Offset(0, 3),
+            ),
+          ],
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.directions_car_filled,
+                color: Colors.white, size: 18),
+            SizedBox(width: 6),
+            Text(
+              'SALIR MODO COCHE',
+              style: TextStyle(
+                color: Colors.white,
+                fontFamily: 'SF Pro Display',
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+                letterSpacing: 0.6,
               ),
             ),
           ],
@@ -1602,12 +2202,14 @@ class _QuickPill extends StatelessWidget {
   final String label;
   final bool active;
   final VoidCallback onTap;
+  final bool big;
 
   const _QuickPill({
     Key? key,
     required this.label,
     required this.active,
     required this.onTap,
+    this.big = false,
   }) : super(key: key);
 
   @override
@@ -1618,11 +2220,11 @@ class _QuickPill extends StatelessWidget {
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 180),
         curve: Curves.easeInOut,
-        padding: const EdgeInsets.symmetric(horizontal: 18),
+        padding: EdgeInsets.symmetric(horizontal: big ? 20 : 18),
         alignment: Alignment.center,
         decoration: BoxDecoration(
           color: active ? GlobalMethods.blueColor : brand.surface,
-          borderRadius: BorderRadius.circular(22),
+          borderRadius: BorderRadius.circular(big ? 22 : 22),
           border: Border.all(
             color: active ? GlobalMethods.blueColor : brand.border,
             width: 1.2,
@@ -1642,8 +2244,8 @@ class _QuickPill extends StatelessWidget {
           style: TextStyle(
             color: active ? Colors.white : brand.textPrimary,
             fontFamily: 'SF Pro Display',
-            fontSize: 12,
-            fontWeight: active ? FontWeight.w700 : FontWeight.w600,
+            fontSize: big ? 13 : 12,
+            fontWeight: active ? FontWeight.w800 : FontWeight.w600,
             letterSpacing: 0.6,
           ),
         ),

--- a/lib/ui/pages/map/map_style.dart
+++ b/lib/ui/pages/map/map_style.dart
@@ -1,0 +1,29 @@
+/// Custom Google Maps JSON style aligned with the app's cream/atlántico
+/// palette (see `AppColors`). Land uses cream tones, water a muted atlántico,
+/// POIs/transit are hidden so our restaurant markers stand out.
+const String kMapStyleLight = '''
+[
+  {"elementType":"geometry","stylers":[{"color":"#F8F1E2"}]},
+  {"elementType":"labels.icon","stylers":[{"visibility":"off"}]},
+  {"elementType":"labels.text.fill","stylers":[{"color":"#4A3A2A"}]},
+  {"elementType":"labels.text.stroke","stylers":[{"color":"#F8F1E2"}]},
+  {"featureType":"administrative","elementType":"geometry.stroke","stylers":[{"color":"#D4A96A"},{"weight":0.6}]},
+  {"featureType":"administrative.land_parcel","stylers":[{"visibility":"off"}]},
+  {"featureType":"administrative.locality","elementType":"labels.text.fill","stylers":[{"color":"#1A0D00"}]},
+  {"featureType":"administrative.neighborhood","elementType":"labels.text.fill","stylers":[{"color":"#4A3A2A"}]},
+  {"featureType":"poi","stylers":[{"visibility":"off"}]},
+  {"featureType":"poi.park","elementType":"geometry","stylers":[{"color":"#E8DBC0"}]},
+  {"featureType":"poi.park","elementType":"labels","stylers":[{"visibility":"off"}]},
+  {"featureType":"road","elementType":"geometry","stylers":[{"color":"#FFFFFF"}]},
+  {"featureType":"road","elementType":"labels.text.fill","stylers":[{"color":"#7A6A58"}]},
+  {"featureType":"road","elementType":"labels.text.stroke","stylers":[{"color":"#FFFFFF"}]},
+  {"featureType":"road.highway","elementType":"geometry","stylers":[{"color":"#F2D8A6"}]},
+  {"featureType":"road.highway","elementType":"geometry.stroke","stylers":[{"color":"#D4A96A"}]},
+  {"featureType":"road.highway.controlled_access","elementType":"geometry","stylers":[{"color":"#E8C58A"}]},
+  {"featureType":"road.local","elementType":"geometry","stylers":[{"color":"#FCF7EC"}]},
+  {"featureType":"transit","stylers":[{"visibility":"off"}]},
+  {"featureType":"water","elementType":"geometry","stylers":[{"color":"#A6CDDB"}]},
+  {"featureType":"water","elementType":"labels.text.fill","stylers":[{"color":"#3E7A93"}]},
+  {"featureType":"water","elementType":"labels.text.stroke","stylers":[{"color":"#A6CDDB"}]}
+]
+''';

--- a/lib/ui/pages/new_home/new_home_body.dart
+++ b/lib/ui/pages/new_home/new_home_body.dart
@@ -17,6 +17,7 @@ import 'package:guachinches/ui/pages/new_home/sheets/island_picker_sheet.dart';
 import 'package:guachinches/ui/pages/new_home/sheets/zone_picker_sheet.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/canarian_specialties_section.dart';
 import 'package:guachinches/ui/pages/curated_list_detail/curated_list_detail_screen.dart';
+import 'package:guachinches/ui/pages/discover/discover_screen.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/card_curated_list.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/card_horizontal.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/card_nearby_minimap.dart';
@@ -92,11 +93,15 @@ class _NewHomeBodyState extends State<NewHomeBody> {
     final filters = widget.filters;
     final zoneLabel = filters.zoneLabel ?? filters.islandLabel;
 
-    // Restaurantes para la sección "HOY EN..." — solo los que tienen
-    // horariosJson y están realmente abiertos ahora. El campo `r.open`
-    // viene del parser legacy y no es de confianza.
+    // Restaurantes para la sección "HOY EN..." — abiertos ahora y filtrados
+    // por type/categoría según la hora (Bar/Cafetería para desayunos,
+    // Terraza/Con vistas para atardecer, Restaurantes/Tascas para cenas...).
+    // Ver lib/utils/contextual_pool.dart para el mapeo. Si la intersección
+    // queda escasa cae al pool abierto sin filtrar.
     final openNow = widget.presenter.filterOpenNow(widget.pool);
-    final todayPool = openNow.take(5).toList();
+    final contextual =
+        widget.presenter.filterContextual(widget.pool, widget.hour);
+    final todayPool = contextual.take(5).toList();
     final showTodaySection = todayPool.isNotEmpty;
 
     // Cantidad de overscroll (positivo cuando el usuario tira hacia abajo)
@@ -106,27 +111,11 @@ class _NewHomeBodyState extends State<NewHomeBody> {
 
     return Stack(
       children: [
-        // ── Hero foto: anclado arriba, scroll-away en scroll normal,
-        //    se estira al hacer pull-down (sin que aparezca cream por arriba) ──
-        Positioned(
-          top: -scrollUp,
-          left: 0,
-          right: 0,
-          height: kHeroHeight + overscroll,
-          child: ParallaxHero(
-            scrollOffset: 0, // posicionamiento manejado por el outer Stack
-            hour: widget.hour,
-            assetImage: _assetForIsland(filters.islandId),
-            zona: filters.zoneLabel ?? filters.islandLabel,
-            islandLabel: filters.islandLabel,
-            zoneIsSet: filters.zoneLabel != null,
-            openCount: openNow.length,
-            onZoneChipTap: () => _showZoneSheet(context),
-            onIslandChipTap: () => _showIslandSheet(context),
-          ),
-        ),
-
         // ── Scroll principal ──────────────────────────
+        // Va PRIMERO en el Stack para que el hero (ver más abajo) quede
+        // por encima en hit-testing y sus chips reciban taps. Las zonas
+        // decorativas del hero usan IgnorePointer internamente para
+        // dejar pasar drags al scroll.
         CustomScrollView(
           controller: widget.scrollCtrl,
           physics: const BouncingScrollPhysics(),
@@ -225,7 +214,9 @@ class _NewHomeBodyState extends State<NewHomeBody> {
               child: SectionHeader(
                 title: 'ÚLTIMAS VISITAS DE JONAY Y JOANA',
                 actionLabel: 'VER TODAS',
-                onAction: () {},
+                onAction: () => Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const DiscoverScreen()),
+                ),
               ),
             ),
             SliverToBoxAdapter(
@@ -294,6 +285,27 @@ class _NewHomeBodyState extends State<NewHomeBody> {
             // Padding inferior pequeño para respirar al final del scroll.
             const SliverToBoxAdapter(child: SizedBox(height: 24)),
           ],
+        ),
+
+        // ── Hero foto: por encima del scroll para que sus chips reciban
+        //    taps. Las capas decorativas internas usan IgnorePointer y
+        //    dejan pasar drags al scroll de fondo.
+        Positioned(
+          top: -scrollUp,
+          left: 0,
+          right: 0,
+          height: kHeroHeight + overscroll,
+          child: ParallaxHero(
+            scrollOffset: 0, // posicionamiento manejado por el outer Stack
+            hour: widget.hour,
+            assetImage: _assetForIsland(filters.islandId),
+            zona: filters.zoneLabel ?? filters.islandLabel,
+            islandLabel: filters.islandLabel,
+            zoneIsSet: filters.zoneLabel != null,
+            openCount: openNow.length,
+            onZoneChipTap: () => _showZoneSheet(context),
+            onIslandChipTap: () => _showIslandSheet(context),
+          ),
         ),
 
         // ── TopFilterBar fija (flotante sobre el scroll) ──

--- a/lib/ui/pages/new_home/new_home_presenter.dart
+++ b/lib/ui/pages/new_home/new_home_presenter.dart
@@ -9,6 +9,7 @@ import 'package:guachinches/data/model/SimpleMunicipality.dart';
 import 'package:guachinches/data/model/TopRestaurants.dart';
 import 'package:guachinches/data/model/Types.dart';
 import 'package:guachinches/data/model/restaurant.dart';
+import 'package:guachinches/utils/contextual_pool.dart';
 import 'package:guachinches/utils/distance_utils.dart';
 import 'package:guachinches/utils/open_now_utils.dart';
 import 'package:guachinches/utils/time_of_day_engine.dart';
@@ -195,6 +196,24 @@ class NewHomePresenter {
       if (r.horariosJson == null) return false;
       return isOpenNow(r.horariosJson, now);
     }).toList();
+  }
+
+  /// Pool para la sección "HOY EN..." alineada con el copy contextual
+  /// del banner. Filtra primero por abierto ahora y luego por type/categoría
+  /// según la hora. Si la intersección queda escasa (< 2) cae al pool
+  /// abierto sin filtrar para no enseñar una sección casi vacía.
+  List<Restaurant> filterContextual(List<Restaurant> pool, int hour) {
+    final openNow = filterOpenNow(pool);
+    final cfg = contextualFilterFor(hour);
+    if (cfg.isEmpty) return openNow;
+    final filtered = openNow.where((r) {
+      final typeOk = cfg.typeIds.isEmpty || cfg.typeIds.contains(r.type);
+      final catOk = cfg.categoryIds.isEmpty ||
+          r.categoriaRestaurantes
+              .any((c) => cfg.categoryIds.contains(c.categoriaId));
+      return typeOk && catOk;
+    }).toList();
+    return filtered.length >= 2 ? filtered : openNow;
   }
 
   List<Restaurant> filterClosingSoon(List<Restaurant> pool) {

--- a/lib/ui/pages/new_home/new_home_tab_scaffold.dart
+++ b/lib/ui/pages/new_home/new_home_tab_scaffold.dart
@@ -4,7 +4,7 @@ import 'package:guachinches/config/brand_colors.dart';
 import 'package:guachinches/data/cubit/menu/menu_cubit.dart';
 import 'package:guachinches/ui/pages/new_home/new_home_screen.dart';
 
-/// Tabs de la app: EXPLORA · LISTAS · MAPA · VIDEOS · PERFIL.
+/// Tabs de la app: EXPLORA · LISTAS · MAPA · VISITAS · PERFIL.
 /// Usa BottomNavigationBar clásico (Material) en la parte inferior.
 class NewHomeTabScaffold extends StatefulWidget {
   /// Lista de 5 widgets para los slots EXPLORA, LISTAS, MAPA, VIDEOS, PERFIL.
@@ -39,9 +39,9 @@ class _NewHomeTabScaffoldState extends State<NewHomeTabScaffold> {
       label: 'Mapa',
     ),
     BottomNavigationBarItem(
-      icon: Icon(Icons.play_circle_outline_rounded),
-      activeIcon: Icon(Icons.play_circle_rounded),
-      label: 'Videos',
+      icon: Icon(Icons.movie_outlined),
+      activeIcon: Icon(Icons.movie_rounded),
+      label: 'Visitas',
     ),
     BottomNavigationBarItem(
       icon: Icon(Icons.person_outline_rounded),
@@ -75,7 +75,7 @@ class _NewHomeTabScaffoldState extends State<NewHomeTabScaffold> {
           NewHomeScreen(),
           _PlaceholderTab('Listas'),
           _PlaceholderTab('Mapa'),
-          _PlaceholderTab('Videos'),
+          _PlaceholderTab('Visitas'),
           _PlaceholderTab('Perfil'),
         ];
 

--- a/lib/ui/pages/new_home/widgets/parallax_hero.dart
+++ b/lib/ui/pages/new_home/widgets/parallax_hero.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:guachinches/config/app_colors.dart';
 import 'package:guachinches/config/brand_colors.dart';
 import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/ui/components/weather_layer.dart';
 import 'package:guachinches/utils/time_of_day_engine.dart';
 import 'starfield_painter.dart';
 import 'sun_moon_arc.dart';
@@ -58,34 +59,50 @@ class ParallaxHero extends StatelessWidget {
       child: Stack(
         clipBehavior: Clip.hardEdge,
         children: [
-          // Foto con parallax
-          RepaintBoundary(
-            child: Positioned(
-              top: -scrollOffset * 0.4,
-              left: 0, right: 0,
-              height: heroH + 40,
-              child: _buildPhoto(context),
+          // Capas decorativas → IgnorePointer para que drags pasen al
+          // CustomScrollView que está detrás (sigue scrolleando al
+          // arrastrar sobre la foto). Solo el contenido editorial (chip)
+          // captura taps.
+          IgnorePointer(
+            child: Stack(
+              clipBehavior: Clip.hardEdge,
+              children: [
+                // Foto con parallax
+                RepaintBoundary(
+                  child: Positioned(
+                    top: -scrollOffset * 0.4,
+                    left: 0, right: 0,
+                    height: heroH + 40,
+                    child: _buildPhoto(context),
+                  ),
+                ),
+                // Tinte de hora
+                AnimatedContainer(
+                  duration: const Duration(milliseconds: 800),
+                  color: tint,
+                ),
+                // Capa meteorológica: consulta tiempo real (Open-Meteo) y
+                // compone nubes/lluvia según condición actual.
+                const Positioned.fill(child: WeatherLayer()),
+                // Degradado mínimo solo al final del hero
+                Positioned(
+                  bottom: 0, left: 0, right: 0, height: 30,
+                  child: _buildFadeGradient(context),
+                ),
+                // Starfield
+                if (starOpacity > 0)
+                  StarfieldWidget(
+                    opacity: starOpacity,
+                    heroSize: Size(heroW, heroH),
+                  ),
+                // Sol / Luna
+                SunMoonArc(
+                    hour: hour, heroWidth: heroW, heroHeight: heroH),
+              ],
             ),
           ),
-          // Tinte de hora
-          AnimatedContainer(
-            duration: const Duration(milliseconds: 800),
-            color: tint,
-          ),
-          // Degradado mínimo solo al final del hero (transición foto → scaffold)
-          Positioned(
-            bottom: 0, left: 0, right: 0, height: 30,
-            child: _buildFadeGradient(context),
-          ),
-          // Starfield
-          if (starOpacity > 0)
-            StarfieldWidget(
-              opacity: starOpacity,
-              heroSize: Size(heroW, heroH),
-            ),
-          // Sol / Luna
-          SunMoonArc(hour: hour, heroWidth: heroW, heroHeight: heroH),
-          // Contenido editorial
+          // Contenido editorial — fuera del IgnorePointer, así el chip
+          // de zona/isla recibe taps.
           Positioned(
             bottom: 0, left: 0, right: 0,
             child: _buildEditorialContent(context, greeting, copy),

--- a/lib/ui/pages/onboarding_flow/onboarding_flow_screen.dart
+++ b/lib/ui/pages/onboarding_flow/onboarding_flow_screen.dart
@@ -1,0 +1,1378 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/data/cubit/location/location_cubit.dart';
+import 'package:guachinches/data/cubit/new_home/islands_cubit.dart';
+import 'package:guachinches/data/cubit/new_home/new_home_filters_cubit.dart';
+import 'package:guachinches/data/model/Island.dart';
+import 'package:guachinches/globalMethods.dart';
+import 'package:guachinches/ui/pages/login/login.dart';
+import 'package:guachinches/ui/pages/register/register.dart';
+import 'package:guachinches/ui/pages/splash_screen/splash_screen.dart';
+
+/// Onboarding editorial — 6 pantallas:
+///   intro · nombre · isla · gustos · ubicación · cuenta
+/// Persiste preferencias en flutter_secure_storage y, si es posible,
+/// en NewHomeFiltersCubit para personalizar el home al entrar.
+class OnboardingFlow extends StatefulWidget {
+  const OnboardingFlow({super.key});
+
+  @override
+  State<OnboardingFlow> createState() => _OnboardingFlowState();
+}
+
+class _OnboardingFlowState extends State<OnboardingFlow> {
+  static const _storage = FlutterSecureStorage();
+  final _ctrl = PageController();
+
+  // Estado recolectado
+  String _name = '';
+  Island? _island;
+  final Set<String> _tastes = {};
+
+  static const _totalSteps = 4; // nombre · isla · gustos · ubicación
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  void _go(int next) {
+    _ctrl.animateToPage(
+      next,
+      duration: const Duration(milliseconds: 320),
+      curve: Curves.easeOutCubic,
+    );
+    HapticFeedback.selectionClick();
+  }
+
+  Future<void> _finish() async {
+    await _storage.write(key: 'onBoardingFinished', value: 'true');
+    if (_name.isNotEmpty) {
+      await _storage.write(key: 'onb_name', value: _name);
+    }
+    if (_island != null) {
+      await _storage.write(key: 'prefIslandId', value: _island!.id);
+      try {
+        context.read<NewHomeFiltersCubit>().selectIsland(
+              id: _island!.id,
+              key: _island!.key ?? '',
+              label: _island!.name,
+            );
+      } catch (_) {}
+    }
+    if (_tastes.isNotEmpty) {
+      await _storage.write(key: 'prefTastes', value: _tastes.join(','));
+    }
+  }
+
+  Future<void> _skipAll() async {
+    await _finish();
+    if (!mounted) return;
+    GlobalMethods().pushAndReplacement(context, SplashScreen());
+  }
+
+  Future<void> _goToLogin() async {
+    await _finish();
+    if (!mounted) return;
+    // Push (no replace) para que Login pueda volver al onboarding
+    // y muestre sus botones de cerrar/saltar (canPop == true).
+    GlobalMethods().pushPage(
+      context,
+      const Login('Inicia sesión para sincronizar tus favoritos.'),
+    );
+  }
+
+  Future<void> _goToRegister() async {
+    await _finish();
+    if (!mounted) return;
+    GlobalMethods().pushPage(context, Register());
+  }
+
+  // ─── Build ──────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    // Onboarding siempre en light mode — usamos los tokens de la paleta
+    // crema/ink ignorando el ThemeMode global. defaultTextColor controla
+    // los estilos que no especifican color explícito.
+    AppTextStyles.defaultTextColor = AppColors.ink;
+    return Scaffold(
+      backgroundColor: AppColors.crema,
+      body: AnnotatedRegion<SystemUiOverlayStyle>(
+        value: SystemUiOverlayStyle.dark.copyWith(
+          statusBarColor: Colors.transparent,
+          systemNavigationBarColor: AppColors.crema,
+        ),
+        child: SafeArea(
+          child: PageView(
+            controller: _ctrl,
+            physics: const NeverScrollableScrollPhysics(),
+            children: [
+              _StepWelcome(
+                onStart: () => _go(1),
+                onLogin: _goToLogin,
+              ),
+              _StepName(
+                step: 1,
+                total: _totalSteps,
+                initial: _name,
+                onBack: () => _go(0),
+                onContinue: (v) {
+                  setState(() => _name = v.trim());
+                  _go(2);
+                },
+              ),
+              _StepIsland(
+                step: 2,
+                total: _totalSteps,
+                userName: _name,
+                selectedId: _island?.id,
+                onBack: () => _go(1),
+                onContinue: (island) {
+                  setState(() => _island = island);
+                  _go(3);
+                },
+              ),
+              _StepTastes(
+                step: 3,
+                total: _totalSteps,
+                selected: _tastes,
+                onBack: () => _go(2),
+                onContinue: (set) {
+                  setState(() {
+                    _tastes
+                      ..clear()
+                      ..addAll(set);
+                  });
+                  _go(4);
+                },
+              ),
+              _StepLocation(
+                step: 4,
+                total: _totalSteps,
+                onBack: () => _go(3),
+                onContinue: () => _go(5),
+              ),
+              _StepAccount(
+                onCreateAccount: _goToRegister,
+                onLogin: _goToLogin,
+                onSkip: _skipAll,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// PASO 0 · Welcome
+// ─────────────────────────────────────────────────────────────────────
+
+class _StepWelcome extends StatelessWidget {
+  final VoidCallback onStart;
+  final VoidCallback onLogin;
+
+  const _StepWelcome({required this.onStart, required this.onLogin});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 8, 24, 16),
+      child: Column(
+        children: [
+          const Spacer(flex: 1),
+          const _SunsetIllustration(),
+          const Spacer(flex: 1),
+          Text(
+            'VISITADO POR\nGUACHINCHESMODERNOS',
+            textAlign: TextAlign.center,
+            style: AppTextStyles.eyebrow(
+              size: 11,
+              color: AppColors.inkMuted,
+            ),
+          ),
+          const SizedBox(height: 14),
+          Text(
+            '¿DÓNDE\nCOMEMOS\nHOY?',
+            textAlign: TextAlign.center,
+            style: AppTextStyles.displayHero(size: 56, color: AppColors.ink),
+          ),
+          const SizedBox(height: 18),
+          Text(
+            '"La guía gastronómica de Canarias por la gente que de verdad come en Canarias."',
+            textAlign: TextAlign.center,
+            style: AppTextStyles.editorial(
+              size: 14,
+              color: AppColors.inkSoft,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '— Jonay y Joana',
+            textAlign: TextAlign.center,
+            style: AppTextStyles.ui(
+              size: 11,
+              weight: FontWeight.w600,
+              color: AppColors.inkMuted,
+            ),
+          ),
+          const Spacer(flex: 2),
+          _PrimaryButton(label: 'EMPEZAR', onTap: onStart),
+          const SizedBox(height: 12),
+          GestureDetector(
+            onTap: onLogin,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                'Ya tengo cuenta · Iniciar sesión',
+                style: AppTextStyles.ui(
+                  size: 13,
+                  weight: FontWeight.w600,
+                  color: AppColors.inkSoft,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SunsetIllustration extends StatelessWidget {
+  const _SunsetIllustration();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 220,
+      child: Stack(
+        alignment: Alignment.bottomCenter,
+        children: [
+          // Halo del sol
+          Align(
+            alignment: const Alignment(0, -0.35),
+            child: Container(
+              width: 220,
+              height: 220,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: RadialGradient(
+                  colors: [
+                    AppColors.sol.withOpacity(0.30),
+                    AppColors.sol.withOpacity(0.0),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          // Sol
+          Align(
+            alignment: const Alignment(0, -0.45),
+            child: Container(
+              width: 88,
+              height: 88,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: AppColors.sol,
+              ),
+            ),
+          ),
+          // Montañas
+          Positioned.fill(
+            child: CustomPaint(painter: _MountainsPainter()),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MountainsPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = AppColors.tierra.withOpacity(0.55);
+    final w = size.width;
+    final h = size.height;
+    final p = Path()
+      ..moveTo(0, h)
+      ..lineTo(0, h * 0.65)
+      ..lineTo(w * 0.18, h * 0.50)
+      ..lineTo(w * 0.32, h * 0.62)
+      ..lineTo(w * 0.50, h * 0.30)
+      ..lineTo(w * 0.66, h * 0.55)
+      ..lineTo(w * 0.82, h * 0.45)
+      ..lineTo(w, h * 0.65)
+      ..lineTo(w, h)
+      ..close();
+    canvas.drawPath(p, paint);
+
+    final paint2 = Paint()..color = AppColors.tierra;
+    final p2 = Path()
+      ..moveTo(0, h)
+      ..lineTo(0, h * 0.78)
+      ..lineTo(w * 0.25, h * 0.68)
+      ..lineTo(w * 0.45, h * 0.80)
+      ..lineTo(w * 0.70, h * 0.65)
+      ..lineTo(w, h * 0.80)
+      ..lineTo(w, h)
+      ..close();
+    canvas.drawPath(p2, paint2);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// PASO 1 · Nombre
+// ─────────────────────────────────────────────────────────────────────
+
+class _StepName extends StatefulWidget {
+  final int step;
+  final int total;
+  final String initial;
+  final VoidCallback onBack;
+  final ValueChanged<String> onContinue;
+
+  const _StepName({
+    required this.step,
+    required this.total,
+    required this.initial,
+    required this.onBack,
+    required this.onContinue,
+  });
+
+  @override
+  State<_StepName> createState() => _StepNameState();
+}
+
+class _StepNameState extends State<_StepName> {
+  late final TextEditingController _ctrl;
+  final _focus = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = TextEditingController(text: widget.initial);
+    _ctrl.addListener(() => setState(() {}));
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focus.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    _focus.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final value = _ctrl.text.trim();
+    return _StepShell(
+      step: widget.step,
+      total: widget.total,
+      onBack: widget.onBack,
+      eyebrow: 'PASO ${widget.step} DE ${widget.total}',
+      title: '¿CÓMO TE\nLLAMAS?',
+      subtitle: 'Solo lo usamos para saludarte. Nada más.',
+      cta: 'CONTINUAR',
+      ctaEnabled: value.length >= 2,
+      onCta: () => widget.onContinue(_ctrl.text),
+      child: Padding(
+        padding: const EdgeInsets.only(top: 12),
+        child: TextField(
+          controller: _ctrl,
+          focusNode: _focus,
+          textInputAction: TextInputAction.done,
+          textCapitalization: TextCapitalization.words,
+          autofocus: true,
+          cursorColor: AppColors.atlantico,
+          style: AppTextStyles.displayHero(size: 22, color: AppColors.ink),
+          onSubmitted: (_) {
+            if (value.length >= 2) widget.onContinue(_ctrl.text);
+          },
+          decoration: InputDecoration(
+            hintText: 'Tu nombre',
+            hintStyle: AppTextStyles.ui(
+              size: 18,
+              color: AppColors.inkMuted,
+            ),
+            filled: true,
+            fillColor: AppColors.cremaSoft,
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(14),
+              borderSide: BorderSide(color: AppColors.borderCreamMd),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(14),
+              borderSide: BorderSide(color: AppColors.borderCreamMd),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(14),
+              borderSide:
+                  const BorderSide(color: AppColors.atlantico, width: 1.6),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// PASO 2 · Isla
+// ─────────────────────────────────────────────────────────────────────
+
+class _StepIsland extends StatefulWidget {
+  final int step;
+  final int total;
+  final String userName;
+  final String? selectedId;
+  final VoidCallback onBack;
+  final ValueChanged<Island> onContinue;
+
+  const _StepIsland({
+    required this.step,
+    required this.total,
+    required this.userName,
+    required this.selectedId,
+    required this.onBack,
+    required this.onContinue,
+  });
+
+  @override
+  State<_StepIsland> createState() => _StepIslandState();
+}
+
+class _StepIslandState extends State<_StepIsland> {
+  String? _selectedId;
+  Island? _selected;
+
+  static const _islandEmoji = {
+    'tenerife': '🏔',
+    'gran canaria': '🌅',
+    'lanzarote': '🌋',
+    'fuerteventura': '🏝',
+    'la palma': '🌿',
+    'la gomera': '🌲',
+    'el hierro': '🌊',
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedId = widget.selectedId;
+  }
+
+  String _iconFor(String name) {
+    final n = name.toLowerCase().trim();
+    return _islandEmoji[n] ?? '🏝';
+  }
+
+  String _greeting() {
+    final n = widget.userName.trim();
+    if (n.isEmpty) return '¿EN QUÉ\nISLA ESTÁS?';
+    final cap = '${n[0].toUpperCase()}${n.substring(1).toLowerCase()}';
+    return '$cap,\n¿EN QUÉ ISLA\nESTÁS?';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _StepShell(
+      step: widget.step,
+      total: widget.total,
+      onBack: widget.onBack,
+      eyebrow: 'PASO ${widget.step} DE ${widget.total}',
+      title: _greeting(),
+      subtitle:
+          'Te enseñamos primero lo de aquí. Puedes cambiar siempre que quieras.',
+      cta: 'CONTINUAR',
+      ctaEnabled: _selected != null,
+      onCta: () => widget.onContinue(_selected!),
+      child: BlocBuilder<IslandsCubit, IslandsState>(
+        builder: (context, state) {
+          if (state is IslandsLoaded && state.islands.isNotEmpty) {
+            final list = [...state.islands]
+              ..sort((a, b) => a.position.compareTo(b.position));
+            return _IslandsGrid(
+              islands: list,
+              selectedId: _selectedId,
+              iconFor: _iconFor,
+              onTap: (i) => setState(() {
+                _selectedId = i.id;
+                _selected = i;
+              }),
+            );
+          }
+          if (state is IslandsFailure) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 24),
+              child: Text(
+                'No pudimos cargar las islas. Puedes seguir y elegirla más tarde.',
+                textAlign: TextAlign.center,
+                style: AppTextStyles.ui(
+                  size: 13,
+                  color: AppColors.inkMuted,
+                ),
+              ),
+            );
+          }
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 40),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _IslandsGrid extends StatelessWidget {
+  final List<Island> islands;
+  final String? selectedId;
+  final String Function(String name) iconFor;
+  final ValueChanged<Island> onTap;
+
+  const _IslandsGrid({
+    required this.islands,
+    required this.selectedId,
+    required this.iconFor,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 12,
+        mainAxisSpacing: 12,
+        childAspectRatio: 1.55,
+      ),
+      itemCount: islands.length,
+      itemBuilder: (_, i) {
+        final island = islands[i];
+        final selected = island.id == selectedId;
+        return _IslandCard(
+          name: island.name,
+          icon: iconFor(island.name),
+          selected: selected,
+          onTap: () => onTap(island),
+        );
+      },
+    );
+  }
+}
+
+class _IslandCard extends StatelessWidget {
+  final String name;
+  final String icon;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _IslandCard({
+    required this.name,
+    required this.icon,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 160),
+          padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+          decoration: BoxDecoration(
+            color: AppColors.cremaSoft,
+            border: Border.all(
+              color: selected
+                  ? AppColors.atlantico
+                  : AppColors.borderCreamMd,
+              width: selected ? 1.6 : 1.0,
+            ),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Stack(
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(icon, style: const TextStyle(fontSize: 26)),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      name.toUpperCase(),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTextStyles.displayHero(
+                        size: 14,
+                        color: AppColors.ink,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              if (selected)
+                Positioned(
+                  right: 0,
+                  top: 0,
+                  child: Container(
+                    width: 22,
+                    height: 22,
+                    alignment: Alignment.center,
+                    decoration: const BoxDecoration(
+                      color: AppColors.atlantico,
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(Icons.check_rounded,
+                        size: 14, color: Colors.white),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// PASO 3 · Gustos
+// ─────────────────────────────────────────────────────────────────────
+
+class _Taste {
+  final String key;
+  final String emoji;
+  final String label;
+  final Color accent;
+  const _Taste(this.key, this.emoji, this.label, this.accent);
+}
+
+const List<_Taste> _kTastes = [
+  _Taste('guachinches', '🍷', 'GUACHINCHES TRADICIONALES', AppColors.tierra),
+  _Taste('mariscos', '🦐', 'MARISCOS', AppColors.atlantico),
+  _Taste('carnes', '🥩', 'CARNES', AppColors.mojo),
+  _Taste('quesos', '🧀', 'QUESOS', AppColors.sol),
+  _Taste('vegano', '🌱', 'VEGANO', AppColors.laurisilva),
+  _Taste('cafes', '☕️', 'CAFÉS', AppColors.tierra),
+  _Taste('tapas', '🍤', 'TAPAS', AppColors.atlantico),
+  _Taste('mojo_picon', '🌶', 'MOJO PICÓN', AppColors.mojo),
+  _Taste('vino_local', '🍇', 'VINO LOCAL', AppColors.tierra),
+  _Taste('postres', '🍰', 'POSTRES', AppColors.atlanticoClaro),
+  _Taste('pizzas', '🍕', 'PIZZAS', AppColors.mojo),
+  _Taste('cocina_canaria', '🍌', 'COCINA CANARIA', AppColors.sol),
+  _Taste('tradicional', '🏠', 'TRADICIONAL', AppColors.tierra),
+  _Taste('moderno', '✨', 'MODERNO', AppColors.atlantico),
+];
+
+class _StepTastes extends StatefulWidget {
+  final int step;
+  final int total;
+  final Set<String> selected;
+  final VoidCallback onBack;
+  final ValueChanged<Set<String>> onContinue;
+
+  const _StepTastes({
+    required this.step,
+    required this.total,
+    required this.selected,
+    required this.onBack,
+    required this.onContinue,
+  });
+
+  @override
+  State<_StepTastes> createState() => _StepTastesState();
+}
+
+class _StepTastesState extends State<_StepTastes> {
+  late Set<String> _set;
+
+  @override
+  void initState() {
+    super.initState();
+    _set = {...widget.selected};
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final reachedMin = _set.length >= 3;
+    final selectedCount = _set.length;
+    return _StepShell(
+      step: widget.step,
+      total: widget.total,
+      onBack: widget.onBack,
+      eyebrow: 'PASO ${widget.step} DE ${widget.total}',
+      title: '¿QUÉ TE\nTIRA MÁS?',
+      subtitle:
+          'Elige lo que te gusta y te lo enseñamos primero. Mínimo 3.',
+      cta: reachedMin
+          ? 'CONTINUAR'
+          : 'ELIGE ${3 - _set.length} MÁS',
+      ctaEnabled: reachedMin,
+      onCta: () => widget.onContinue(_set),
+      titleTrailing: _SelectionCounter(count: selectedCount, total: _kTastes.length),
+      child: Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Wrap(
+          spacing: 10,
+          runSpacing: 10,
+          children: _kTastes.map((t) {
+            final selected = _set.contains(t.key);
+            return _TasteChip(
+              taste: t,
+              selected: selected,
+              onTap: () {
+                HapticFeedback.selectionClick();
+                setState(() {
+                  if (selected) {
+                    _set.remove(t.key);
+                  } else {
+                    _set.add(t.key);
+                  }
+                });
+              },
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectionCounter extends StatelessWidget {
+  final int count;
+  final int total;
+  const _SelectionCounter({required this.count, required this.total});
+
+  @override
+  Widget build(BuildContext context) {
+    final filled = count > 0;
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 160),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: filled ? AppColors.atlantico : AppColors.cremaSoft,
+        border: Border.all(
+          color: filled ? AppColors.atlantico : AppColors.borderCreamMd,
+        ),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        '$count / $total',
+        style: AppTextStyles.displaySection(size: 11).copyWith(
+          color: filled ? Colors.white : AppColors.inkSoft,
+          letterSpacing: 0.6,
+        ),
+      ),
+    );
+  }
+}
+
+class _TasteChip extends StatelessWidget {
+  final _Taste taste;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _TasteChip({
+    required this.taste,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = selected ? taste.accent : AppColors.cremaSoft;
+    final fg = selected ? Colors.white : AppColors.ink;
+    final border = selected ? taste.accent : AppColors.borderCreamMd;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(999),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+          padding: EdgeInsets.fromLTRB(12, 10, selected ? 14 : 14, 10),
+          decoration: BoxDecoration(
+            color: bg,
+            border: Border.all(color: border, width: selected ? 0 : 1.0),
+            borderRadius: BorderRadius.circular(999),
+            boxShadow: selected
+                ? [
+                    BoxShadow(
+                      color: taste.accent.withOpacity(0.30),
+                      blurRadius: 12,
+                      offset: const Offset(0, 4),
+                    ),
+                  ]
+                : null,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 24,
+                height: 24,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: selected
+                      ? Colors.white.withOpacity(0.20)
+                      : taste.accent.withOpacity(0.12),
+                  shape: BoxShape.circle,
+                ),
+                child: Text(
+                  taste.emoji,
+                  style: const TextStyle(fontSize: 13),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                taste.label,
+                style: AppTextStyles.displaySection(size: 11)
+                    .copyWith(color: fg, letterSpacing: 0.7),
+              ),
+              if (selected) ...[
+                const SizedBox(width: 6),
+                Container(
+                  width: 16,
+                  height: 16,
+                  alignment: Alignment.center,
+                  decoration: const BoxDecoration(
+                    color: Colors.white,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.check_rounded,
+                    size: 12,
+                    color: taste.accent,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// PASO 4 · Ubicación
+// ─────────────────────────────────────────────────────────────────────
+
+class _StepLocation extends StatefulWidget {
+  final int step;
+  final int total;
+  final VoidCallback onBack;
+  final VoidCallback onContinue;
+
+  const _StepLocation({
+    required this.step,
+    required this.total,
+    required this.onBack,
+    required this.onContinue,
+  });
+
+  @override
+  State<_StepLocation> createState() => _StepLocationState();
+}
+
+class _StepLocationState extends State<_StepLocation> {
+  bool _requesting = false;
+
+  Future<void> _activate() async {
+    if (_requesting) return;
+    setState(() => _requesting = true);
+    try {
+      await context.read<LocationCubit>().requestLocation();
+      await const FlutterSecureStorage()
+          .write(key: 'prefLocationAsked', value: 'true');
+    } catch (_) {}
+    if (!mounted) return;
+    setState(() => _requesting = false);
+    widget.onContinue();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _StepShell(
+      step: widget.step,
+      total: widget.total,
+      onBack: widget.onBack,
+      eyebrow: 'PASO ${widget.step} DE ${widget.total} · ÚLTIMO',
+      title: 'LO BUENO,\nCERCA DE TI',
+      subtitle:
+          'Activa tu ubicación y te enseñamos los sitios abiertos a tu alrededor. Sin ubicación también funciona.',
+      cta: _requesting ? 'ACTIVANDO…' : 'ACTIVAR UBICACIÓN',
+      ctaEnabled: !_requesting,
+      onCta: _activate,
+      footer: TextButton(
+        onPressed: widget.onContinue,
+        child: Text(
+          'Ahora no',
+          style: AppTextStyles.ui(
+            size: 13,
+            weight: FontWeight.w600,
+            color: AppColors.inkMuted,
+          ),
+        ),
+      ),
+      child: const Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: Center(child: _LocationPulse()),
+      ),
+    );
+  }
+}
+
+class _LocationPulse extends StatefulWidget {
+  const _LocationPulse();
+
+  @override
+  State<_LocationPulse> createState() => _LocationPulseState();
+}
+
+class _LocationPulseState extends State<_LocationPulse>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 2),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 200,
+      height: 200,
+      child: AnimatedBuilder(
+        animation: _ctrl,
+        builder: (_, __) => Stack(
+          alignment: Alignment.center,
+          children: [
+            for (int i = 0; i < 3; i++) _ring(i),
+            Container(
+              width: 56,
+              height: 56,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: AppColors.atlantico.withOpacity(0.18),
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: AppColors.atlantico,
+                  width: 1.5,
+                ),
+              ),
+              child: const Icon(
+                Icons.my_location_rounded,
+                color: AppColors.atlanticoClaro,
+                size: 22,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _ring(int i) {
+    final t = (_ctrl.value + i / 3) % 1.0;
+    final size = 80 + 120 * t;
+    final opacity = (1.0 - t).clamp(0.0, 1.0) * 0.45;
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: AppColors.atlantico.withOpacity(opacity),
+          width: 1.2,
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// PASO 5 · Cuenta (sin Google/Apple — only email + skip)
+// ─────────────────────────────────────────────────────────────────────
+
+class _StepAccount extends StatelessWidget {
+  final VoidCallback onCreateAccount;
+  final VoidCallback onLogin;
+  final VoidCallback onSkip;
+
+  const _StepAccount({
+    required this.onCreateAccount,
+    required this.onLogin,
+    required this.onSkip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 8, 24, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: GestureDetector(
+              onTap: onSkip,
+              child: Container(
+                width: 36,
+                height: 36,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: AppColors.cremaSoft,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: AppColors.borderCreamMd),
+                ),
+                child: Icon(
+                  Icons.close_rounded,
+                  color: AppColors.ink,
+                  size: 18,
+                ),
+              ),
+            ),
+          ),
+          const Spacer(flex: 1),
+          Center(
+            child: Container(
+              width: 88,
+              height: 88,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [
+                    AppColors.atlantico.withOpacity(0.35),
+                    AppColors.atlantico.withOpacity(0.10),
+                  ],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
+                borderRadius: BorderRadius.circular(24),
+                border: Border.all(color: AppColors.atlantico, width: 1.4),
+              ),
+              child: const Icon(
+                Icons.bookmark_rounded,
+                color: AppColors.atlanticoClaro,
+                size: 38,
+              ),
+            ),
+          ),
+          const SizedBox(height: 22),
+          Center(
+            child: Text(
+              'ANTES DE EMPEZAR',
+              style: AppTextStyles.eyebrow(
+                size: 11,
+                color: AppColors.inkMuted,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'GUARDA TUS\nSITIOS FAVORITOS',
+            textAlign: TextAlign.center,
+            style: AppTextStyles.displayHero(size: 32, color: AppColors.ink),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Sincroniza guardados, listas y reseñas en todos tus dispositivos. Tarda dos segundos.',
+            textAlign: TextAlign.center,
+            style: AppTextStyles.editorial(
+              size: 13,
+              color: AppColors.inkSoft,
+            ),
+          ),
+          const Spacer(flex: 2),
+          _PrimaryButton(label: 'CREAR CUENTA', onTap: onCreateAccount),
+          const SizedBox(height: 10),
+          OutlinedButton(
+            style: OutlinedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              side: const BorderSide(color: AppColors.borderCreamMd),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14),
+              ),
+            ),
+            onPressed: onLogin,
+            child: Text(
+              'YA TENGO CUENTA',
+              style: AppTextStyles.displaySection(size: 12).copyWith(
+                color: AppColors.ink,
+                letterSpacing: 1.0,
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          TextButton(
+            onPressed: onSkip,
+            child: Text(
+              'Saltar y explorar sin cuenta',
+              style: AppTextStyles.ui(
+                size: 13,
+                weight: FontWeight.w600,
+                color: AppColors.inkMuted,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text.rich(
+            TextSpan(
+              text: 'Al continuar aceptas los ',
+              style: AppTextStyles.ui(
+                size: 11,
+                color: AppColors.inkMuted,
+              ),
+              children: [
+                TextSpan(
+                  text: 'Términos',
+                  style: AppTextStyles.ui(
+                    size: 11,
+                    weight: FontWeight.w700,
+                    color: AppColors.inkSoft,
+                  ),
+                ),
+                const TextSpan(text: ' y la '),
+                TextSpan(
+                  text: 'Privacidad',
+                  style: AppTextStyles.ui(
+                    size: 11,
+                    weight: FontWeight.w700,
+                    color: AppColors.inkSoft,
+                  ),
+                ),
+                const TextSpan(text: '. Sin spam, te lo prometemos.'),
+              ],
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Shell común para los pasos 1-4
+// ─────────────────────────────────────────────────────────────────────
+
+class _StepShell extends StatelessWidget {
+  final int step;
+  final int total;
+  final VoidCallback onBack;
+  final String eyebrow;
+  final String title;
+  final String subtitle;
+  final String cta;
+  final bool ctaEnabled;
+  final VoidCallback onCta;
+  final Widget child;
+  final Widget? footer;
+  final Widget? titleTrailing;
+
+  const _StepShell({
+    required this.step,
+    required this.total,
+    required this.onBack,
+    required this.eyebrow,
+    required this.title,
+    required this.subtitle,
+    required this.cta,
+    required this.ctaEnabled,
+    required this.onCta,
+    required this.child,
+    this.footer,
+    this.titleTrailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              GestureDetector(
+                onTap: onBack,
+                behavior: HitTestBehavior.opaque,
+                child: Container(
+                  width: 36,
+                  height: 36,
+                  alignment: Alignment.center,
+                  child: Icon(
+                    Icons.arrow_back_rounded,
+                    color: AppColors.inkSoft,
+                    size: 22,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(child: _ProgressBar(step: step, total: total)),
+              const SizedBox(width: 36),
+            ],
+          ),
+          const SizedBox(height: 22),
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    eyebrow,
+                    style: AppTextStyles.eyebrow(
+                      size: 11,
+                      color: AppColors.inkMuted,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          title,
+                          style: AppTextStyles.displayHero(
+                            size: 38,
+                            color: AppColors.ink,
+                          ),
+                        ),
+                      ),
+                      if (titleTrailing != null) ...[
+                        const SizedBox(width: 12),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8),
+                          child: titleTrailing!,
+                        ),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  Text(
+                    subtitle,
+                    style: AppTextStyles.editorial(
+                      size: 13,
+                      color: AppColors.inkSoft,
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  child,
+                  const SizedBox(height: 24),
+                ],
+              ),
+            ),
+          ),
+          _PrimaryButton(label: cta, onTap: onCta, enabled: ctaEnabled),
+          if (footer != null) Center(child: footer!),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProgressBar extends StatelessWidget {
+  final int step;
+  final int total;
+  const _ProgressBar({required this.step, required this.total});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: List.generate(total, (i) {
+        final filled = i < step;
+        return Expanded(
+          child: Padding(
+            padding: EdgeInsets.only(right: i == total - 1 ? 0 : 6),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 220),
+              height: 4,
+              decoration: BoxDecoration(
+                color: filled
+                    ? AppColors.atlantico
+                    : AppColors.borderCreamMd,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+  final bool enabled;
+
+  const _PrimaryButton({
+    required this.label,
+    required this.onTap,
+    this.enabled = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.atlantico,
+          disabledBackgroundColor: AppColors.cremaOscura,
+          disabledForegroundColor: AppColors.inkMuted,
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+          elevation: 0,
+        ),
+        onPressed: enabled ? onTap : null,
+        child: Text(
+          label,
+          style: AppTextStyles.displaySection(size: 12).copyWith(
+            color: enabled ? Colors.white : AppColors.inkMuted,
+            letterSpacing: 1.2,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/profile/profile_v2.dart
+++ b/lib/ui/pages/profile/profile_v2.dart
@@ -1,230 +1,661 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_svg/svg.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
 import 'package:guachinches/config/brand_colors.dart';
 import 'package:guachinches/data/HttpRemoteRepository.dart';
 import 'package:guachinches/data/RemoteRepository.dart';
 import 'package:guachinches/data/cubit/theme/theme_cubit.dart';
 import 'package:guachinches/data/cubit/user/user_cubit.dart';
 import 'package:guachinches/data/cubit/user/user_state.dart';
+import 'package:guachinches/data/local/sql_lite_local_repository.dart';
 import 'package:guachinches/data/model/Cupones.dart';
 import 'package:guachinches/data/model/restaurant.dart';
 import 'package:guachinches/data/model/user_info.dart';
-import 'package:guachinches/globalMethods.dart';
 import 'package:guachinches/ui/pages/favoritos/favoritos.dart';
-import 'package:guachinches/ui/pages/mis_visitas/mis_visitas.dart';
-import 'package:guachinches/ui/pages/profile/pin.dart';
 import 'package:guachinches/ui/pages/profile/profile_presenter.dart';
 import 'package:guachinches/ui/pages/splash_screen/splash_screen.dart';
 import 'package:guachinches/ui/pages/valoraciones/valoraciones.dart';
 import 'package:http/http.dart';
 
-
 class Profilev2 extends StatefulWidget {
+  const Profilev2({super.key});
 
   @override
   State<Profilev2> createState() => _Profilev2State();
 }
 
-class _Profilev2State extends State<Profilev2> implements ProfileView{
+class _Profilev2State extends State<Profilev2> implements ProfileView {
   late RemoteRepository remoteRepository;
   late ProfilePresenter _presenter;
+  final _localRepo = SqlLiteLocalRepository();
+  final _storage = const FlutterSecureStorage();
+  int _favCount = 0;
 
   @override
   void initState() {
+    super.initState();
     final userCubit = context.read<UserCubit>();
     remoteRepository = HttpRemoteRepository(Client());
     _presenter = ProfilePresenter(this, userCubit, remoteRepository);
+    _loadFavCount();
+    _ensureUserLoaded(userCubit);
+  }
+
+  Future<void> _ensureUserLoaded(UserCubit userCubit) async {
+    if (userCubit.state is UserLoaded) return;
+    final userId = await _storage.read(key: 'userId');
+    if (userId == null || userId.isEmpty) return;
+    await userCubit.getUserInfo(userId);
+  }
+
+  Future<void> _loadFavCount() async {
+    final list = await _localRepo.getRestaurants();
+    if (!mounted) return;
+    setState(() => _favCount = list.length);
+  }
+
+  Future<void> _confirmLogout() async {
+    final ok = await _showConfirm(
+      title: 'Cerrar sesión',
+      message: '¿Seguro que quieres cerrar sesión?',
+      confirmLabel: 'Cerrar sesión',
+      destructive: false,
+    );
+    if (ok == true) _presenter.logOut();
+  }
+
+  Future<void> _confirmDelete() async {
+    final ok = await _showConfirm(
+      title: 'Eliminar cuenta',
+      message:
+          'Esta acción es permanente. Se borrarán todas tus valoraciones y datos.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    );
+    if (ok == true) _presenter.deleteAccount();
+  }
+
+  Future<void> _resetOnboarding() async {
+    final ok = await _showConfirm(
+      title: 'Reiniciar onboarding (DEV)',
+      message:
+          'Se borrarán tu nombre, isla preferida, gustos y el flag de onboarding completado. Volverás a la pantalla de bienvenida al reiniciar.',
+      confirmLabel: 'Reiniciar',
+      destructive: true,
+    );
+    if (ok != true) return;
+    await _storage.delete(key: 'onBoardingFinished');
+    await _storage.delete(key: 'onb_name');
+    await _storage.delete(key: 'prefIslandId');
+    await _storage.delete(key: 'prefTastes');
+    await _storage.delete(key: 'prefLocationAsked');
+    await _storage.delete(key: 'surveyOnboarding2026Shown');
+    if (!mounted) return;
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => SplashScreen()),
+      (_) => false,
+    );
+  }
+
+  Future<bool?> _showConfirm({
+    required String title,
+    required String message,
+    required String confirmLabel,
+    required bool destructive,
+  }) {
+    final brand = context.brand;
+    return showModalBottomSheet<bool>(
+      context: context,
+      backgroundColor: brand.elevated,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetCtx) {
+        final bottom = MediaQuery.of(sheetCtx).padding.bottom;
+        return Padding(
+          padding: EdgeInsets.fromLTRB(20, 12, 20, 16 + bottom),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: brand.textMuted,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 18),
+              Text(
+                title,
+                textAlign: TextAlign.center,
+                style: AppTextStyles.displayHero(size: 20),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                message,
+                textAlign: TextAlign.center,
+                style: AppTextStyles.ui(
+                  size: 13,
+                  color: brand.textSecondary,
+                ),
+              ),
+              const SizedBox(height: 22),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor:
+                      destructive ? AppColors.mojo : AppColors.atlantico,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  elevation: 0,
+                ),
+                onPressed: () => Navigator.pop(sheetCtx, true),
+                child: Text(
+                  confirmLabel.toUpperCase(),
+                  style: AppTextStyles.displaySection(size: 12)
+                      .copyWith(color: Colors.white, letterSpacing: 1.0),
+                ),
+              ),
+              const SizedBox(height: 8),
+              TextButton(
+                onPressed: () => Navigator.pop(sheetCtx, false),
+                child: Text(
+                  'Cancelar',
+                  style: AppTextStyles.ui(
+                    size: 13,
+                    weight: FontWeight.w600,
+                    color: brand.textSecondary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     final brand = context.brand;
-    return CupertinoPageScaffold(
+    return Scaffold(
       backgroundColor: brand.base,
-      child: CustomScrollView(
-        slivers: [
-          CupertinoSliverNavigationBar(
-            backgroundColor: brand.base,
-            largeTitle: Text(
-              'Mi Perfil',
-              style: TextStyle(
-                color: brand.textPrimary,
-                fontFamily: 'SF Pro Display',
-              ),
-            ),
-          ),
-          SliverFillRemaining(
-            hasScrollBody: false,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      BlocBuilder<UserCubit, UserState>(
-                        builder: (context, state) {
-                          UserInfo userInfo = UserInfo();
-                          if (state is UserLoaded) {
-                            userInfo = state.user;
-                            if (userInfo.nombre.isNotEmpty) {
-                              userInfo.nombre =
-                                  userInfo.nombre[0].toUpperCase() +
-                                      userInfo.nombre.substring(1);
-                            }
-                          }
-                          return Container(
-                            decoration: BoxDecoration(
-                              border: Border.all(
-                                color: AppColors.atlantico,
-                                width: 2.0,
-                              ),
-                              borderRadius: BorderRadius.circular(16.0),
-                            ),
-                            height: 100,
-                            child: Padding(
-                              padding: const EdgeInsets.only(left: 16.0),
-                              child: Row(
-                                mainAxisAlignment: MainAxisAlignment.start,
-                                children: [
-                                  Row(
-                                    children: [
-                                      CircleAvatar(
-                                        radius: 40,
-                                        child: Text(
-                                          userInfo.nombre.length > 0
-                                              ? userInfo.nombre[0]
-                                              : '',
-                                          style: const TextStyle(
-                                            fontFamily: 'SF Pro Display',
-                                            fontWeight: FontWeight.bold,
-                                            fontSize: 32,
-                                          ),
-                                        ),
-                                      ),
-                                      Padding(
-                                        padding: const EdgeInsets.only(left: 24.0),
-                                        child: Column(
-                                          mainAxisAlignment: MainAxisAlignment.center,
-                                          crossAxisAlignment: CrossAxisAlignment.start,
-                                          children: [
-                                            Text(
-                                              userInfo.nombre,
-                                              style: TextStyle(
-                                                fontSize: 24,
-                                                fontFamily: 'SF Pro Display',
-                                                color: brand.textPrimary,
-                                              ),
-                                            ),
-                                            Text(
-                                              userInfo.apellidos,
-                                              style: TextStyle(
-                                                fontSize: 16,
-                                                fontFamily: 'SF Pro Display',
-                                                color: brand.textPrimary,
-                                              ),
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ],
-                              ),
-                            ),
-                          );
-                        },
-                      ),
-                      const SizedBox(height: 24),
-                      const _ThemeToggleRow(),
-                      const SizedBox(height: 16),
-                      Text(
-                        "PERFIL",
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontFamily: 'SF Display Pro',
-                          color: brand.textPrimary,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      MenuOption(title: "Valoraciones", asset: "valoraciones.svg", page: ValoracionesPage()),
-                      MenuOption(title: "Mis visitas", asset: "rutas.svg", page: MisVisitasPage()),
-                      MenuOption(title: "Favoritos", asset: "fav.svg", page: FavoritosPage()),
-                      const SizedBox(height: 16),
-                    ],
+      body: SafeArea(
+        child: BlocBuilder<UserCubit, UserState>(
+          builder: (context, state) {
+            UserInfo user = UserInfo();
+            if (state is UserLoaded) user = state.user;
+            final reviewCount = user.valoraciones.length;
+            return ListView(
+              physics: const BouncingScrollPhysics(),
+              padding: const EdgeInsets.fromLTRB(20, 8, 20, 32),
+              children: [
+                _Header(),
+                const SizedBox(height: 8),
+                _ProfileCard(user: user),
+                const SizedBox(height: 20),
+                _StatsRow(
+                  reviewCount: reviewCount,
+                  favCount: _favCount,
+                  onTapReviews: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const ValoracionesPage(),
+                    ),
                   ),
-                  const SizedBox(height: 24),
-                  Column(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Align(
-                        alignment: Alignment.bottomCenter,
-                        child: Column(
-                          children: [
-                            TextButton(
-                              onPressed: () => _presenter.logOut(),
-                              child: Text(
-                                'Cerrar sesion',
-                                style: TextStyle(
-                                  fontFamily: 'SF Pro Display',
-                                  color: brand.textPrimary,
-                                ),
-                              ),
-                            ),
-                            TextButton(
-                              onPressed: () => _presenter.deleteAccount(),
-                              child: Text(
-                                'Eliminar usuario',
-                                style: TextStyle(
-                                  fontFamily: 'SF Pro Display',
-                                  color: brand.textMuted,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
+                  onTapFavs: () async {
+                    await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const FavoritosPage(),
                       ),
-                    ],
+                    );
+                    _loadFavCount();
+                  },
+                ),
+                const SizedBox(height: 24),
+                _SectionLabel('CUENTA'),
+                _MenuTile(
+                  icon: Icons.rate_review_outlined,
+                  iconColor: AppColors.atlanticoClaro,
+                  title: 'Mis valoraciones',
+                  subtitle: reviewCount == 0
+                      ? 'Aún no has valorado'
+                      : '$reviewCount ${reviewCount == 1 ? "reseña" : "reseñas"}',
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const ValoracionesPage(),
+                    ),
+                  ),
+                ),
+                _MenuTile(
+                  icon: Icons.bookmark_border_rounded,
+                  iconColor: AppColors.atlanticoClaro,
+                  title: 'Favoritos',
+                  subtitle: _favCount == 0
+                      ? 'Sin restaurantes guardados'
+                      : '$_favCount ${_favCount == 1 ? "guardado" : "guardados"}',
+                  onTap: () async {
+                    await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const FavoritosPage(),
+                      ),
+                    );
+                    _loadFavCount();
+                  },
+                ),
+                const SizedBox(height: 24),
+                _SectionLabel('AJUSTES'),
+                const _ThemeTile(),
+                const SizedBox(height: 28),
+                _DangerZone(
+                  onLogout: _confirmLogout,
+                  onDelete: _confirmDelete,
+                ),
+                if (kDebugMode) ...[
+                  const SizedBox(height: 28),
+                  _SectionLabel('DEV'),
+                  _MenuTile(
+                    icon: Icons.refresh_rounded,
+                    iconColor: AppColors.mojo,
+                    title: 'Reiniciar onboarding',
+                    subtitle:
+                        'Borra preferencias y vuelve a la pantalla de bienvenida',
+                    onTap: _resetOnboarding,
                   ),
                 ],
-              ),
+                const SizedBox(height: 24),
+                Center(
+                  child: Text(
+                    '¿Dónde Comer Canarias?',
+                    style: AppTextStyles.eyebrow(
+                      size: 10,
+                      color: brand.textMuted,
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  // ProfileView impls (legacy — usados por otros presenters)
+  @override
+  goSplashScreen() {
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => SplashScreen()),
+      (_) => false,
+    );
+  }
+
+  @override
+  updateCupones(List<Cupones> cupones) {}
+
+  @override
+  updateListSql(List<Restaurant> restaurants) {}
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+class _Header extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'TU CUENTA',
+                  style: AppTextStyles.eyebrow(
+                    size: 10,
+                    color: context.brand.textMuted,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Mi perfil',
+                  style: AppTextStyles.displayHero(size: 32),
+                ),
+              ],
             ),
           ),
         ],
       ),
     );
   }
+}
 
+class _ProfileCard extends StatelessWidget {
+  final UserInfo user;
 
-  @override
-  setUserInfo(UserInfo userInfo) {
-    throw UnimplementedError();
+  const _ProfileCard({required this.user});
+
+  String get _displayName {
+    final n = user.nombre.trim();
+    if (n.isEmpty) return 'Usuario';
+    return '${n[0].toUpperCase()}${n.substring(1)}';
+  }
+
+  String get _initial {
+    final n = _displayName;
+    return n.isNotEmpty ? n[0].toUpperCase() : '?';
   }
 
   @override
-  goSplashScreen() {
-    GlobalMethods().pushAndReplacement(context, SplashScreen());
-  }
-
-  @override
-  updateCupones(List<Cupones> cupones) {
-    throw UnimplementedError();
-  }
-
-  @override
-  updateListSql(List<Restaurant> restaurants) {
-    throw UnimplementedError();
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            AppColors.atlantico.withOpacity(0.18),
+            AppColors.profundo.withOpacity(0.10),
+          ],
+        ),
+        border: Border.all(color: brand.borderStrong),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 64,
+            height: 64,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: AppColors.atlantico,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: AppColors.atlantico.withOpacity(0.35),
+                  blurRadius: 14,
+                  spreadRadius: 1,
+                ),
+              ],
+            ),
+            child: Text(
+              _initial,
+              style: AppTextStyles.displayHero(
+                size: 28,
+                color: Colors.white,
+              ),
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _displayName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTextStyles.displayHero(size: 22),
+                ),
+                if (user.apellidos.trim().isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    user.apellidos,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTextStyles.ui(
+                      size: 13,
+                      color: brand.textSecondary,
+                    ),
+                  ),
+                ],
+                if (user.email.trim().isNotEmpty) ...[
+                  const SizedBox(height: 6),
+                  Row(
+                    children: [
+                      Icon(Icons.mail_outline_rounded,
+                          size: 13, color: brand.textMuted),
+                      const SizedBox(width: 4),
+                      Flexible(
+                        child: Text(
+                          user.email,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTextStyles.ui(
+                            size: 12,
+                            color: brand.textMuted,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 
-class _ThemeToggleRow extends StatelessWidget {
-  const _ThemeToggleRow();
+class _StatsRow extends StatelessWidget {
+  final int reviewCount;
+  final int favCount;
+  final VoidCallback onTapReviews;
+  final VoidCallback onTapFavs;
+
+  const _StatsRow({
+    required this.reviewCount,
+    required this.favCount,
+    required this.onTapReviews,
+    required this.onTapFavs,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: _StatCard(
+            icon: Icons.star_rounded,
+            iconColor: AppColors.sol,
+            value: '$reviewCount',
+            label: reviewCount == 1 ? 'valoración' : 'valoraciones',
+            onTap: onTapReviews,
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: _StatCard(
+            icon: Icons.bookmark_rounded,
+            iconColor: AppColors.atlanticoClaro,
+            value: '$favCount',
+            label: favCount == 1 ? 'favorito' : 'favoritos',
+            onTap: onTapFavs,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  final IconData icon;
+  final Color iconColor;
+  final String value;
+  final String label;
+  final VoidCallback onTap;
+
+  const _StatCard({
+    required this.icon,
+    required this.iconColor,
+    required this.value,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+          decoration: BoxDecoration(
+            color: brand.surface,
+            border: Border.all(color: brand.borderStrong),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(icon, size: 18, color: iconColor),
+              const SizedBox(height: 8),
+              Text(
+                value,
+                style: AppTextStyles.displayHero(size: 26),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                label,
+                style: AppTextStyles.ui(
+                  size: 11,
+                  color: brand.textMuted,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  const _SectionLabel(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 0, 10),
+      child: Text(
+        text,
+        style: AppTextStyles.eyebrow(
+          size: 11,
+          color: context.brand.textMuted,
+        ),
+      ),
+    );
+  }
+}
+
+class _MenuTile extends StatelessWidget {
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final String? subtitle;
+  final VoidCallback onTap;
+
+  const _MenuTile({
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    this.subtitle,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(14),
+          child: Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+            decoration: BoxDecoration(
+              color: brand.surface,
+              border: Border.all(color: brand.borderStrong),
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 38,
+                  height: 38,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: iconColor.withOpacity(0.15),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(icon, size: 20, color: iconColor),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: AppTextStyles.ui(
+                          size: 14,
+                          weight: FontWeight.w700,
+                          color: brand.textPrimary,
+                        ),
+                      ),
+                      if (subtitle != null) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          subtitle!,
+                          style: AppTextStyles.ui(
+                            size: 11,
+                            color: brand.textMuted,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right_rounded,
+                  color: brand.textMuted,
+                  size: 22,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ThemeTile extends StatelessWidget {
+  const _ThemeTile();
 
   @override
   Widget build(BuildContext context) {
@@ -232,141 +663,119 @@ class _ThemeToggleRow extends StatelessWidget {
       builder: (_, mode) {
         final isDark = mode == ThemeMode.dark;
         final brand = context.brand;
-        return SizedBox(
-          height: 48,
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            color: brand.surface,
+            border: Border.all(color: brand.borderStrong),
+            borderRadius: BorderRadius.circular(14),
+          ),
           child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Row(
-                children: [
-                  Icon(
-                    isDark ? Icons.dark_mode_rounded : Icons.light_mode_rounded,
-                    size: 24,
-                    color: brand.textPrimary,
-                  ),
-                  const SizedBox(width: 12),
-                  Text(
-                    'Modo oscuro',
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontFamily: 'SF Pro Display',
-                      color: brand.textPrimary,
-                    ),
-                  ),
-                ],
-              ),
-              CupertinoSwitch(
-                value: isDark,
-                activeColor: AppColors.atlantico,
-                onChanged: (v) => context.read<ThemeCubit>().setMode(
-                  v ? ThemeMode.dark : ThemeMode.light,
+              Container(
+                width: 38,
+                height: 38,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: AppColors.sol.withOpacity(0.15),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Icon(
+                  isDark
+                      ? Icons.dark_mode_rounded
+                      : Icons.light_mode_rounded,
+                  size: 20,
+                  color: AppColors.sol,
                 ),
               ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-}
-
-class MenuOption extends StatelessWidget {
-  final String title;
-  final String asset;
-  final Widget? page;
-
-  const MenuOption({
-    Key? key, required this.asset, required this.title, this.page,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final brand = context.brand;
-    return GestureDetector(
-      onTap: () => GlobalMethods().pushPage(context, page!),
-      child: Container(
-        height: 48,
-        child: Column(
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Row(
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Container(
-                      alignment: Alignment.center,
-                      width: 24,
-                      height: 24,
-                      child: SvgPicture.asset(
-                        "assets/images/" + asset,
+                    Text(
+                      'Modo oscuro',
+                      style: AppTextStyles.ui(
+                        size: 14,
+                        weight: FontWeight.w700,
                         color: brand.textPrimary,
                       ),
                     ),
-                    Padding(
-                      padding: const EdgeInsets.only(left: 8.0),
-                      child: Text(
-                        this.title,
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontFamily: 'SF Pro Display',
-                          color: brand.textPrimary,
-                        ),
+                    const SizedBox(height: 2),
+                    Text(
+                      isDark ? 'Activado' : 'Desactivado',
+                      style: AppTextStyles.ui(
+                        size: 11,
+                        color: brand.textMuted,
                       ),
                     ),
                   ],
                 ),
-                Icon(
-                  Icons.arrow_forward_ios_rounded,
-                  size: 16,
-                  color: brand.textPrimary,
-                ),
-              ],
-            ),
-            Padding(
-              padding: const EdgeInsets.only(left: 32.0),
-              child: Divider(color: brand.border),
-            ),
-          ],
-        ),
-      ),
+              ),
+              Switch(
+                value: isDark,
+                activeColor: Colors.white,
+                activeTrackColor: AppColors.atlantico,
+                onChanged: (v) => context.read<ThemeCubit>().setMode(
+                      v ? ThemeMode.dark : ThemeMode.light,
+                    ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }
 
-class Pin extends StatelessWidget {
-  final String title;
-  final String asset;
+class _DangerZone extends StatelessWidget {
+  final VoidCallback onLogout;
+  final VoidCallback onDelete;
 
-  const Pin({Key? key, required this.title, required this.asset}) : super(key: key);
+  const _DangerZone({
+    required this.onLogout,
+    required this.onDelete,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        GlobalMethods().pushPageWithFocus(
-          context,
-          PinDetail(
-            title: title,
-            asset: asset,
-            description: "Haz visitado algún restaurante dificil de llegar de esos que tienes que preguntar 20 veces antes de encontrarlo",
+    final brand = context.brand;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        OutlinedButton.icon(
+          onPressed: onLogout,
+          icon: Icon(Icons.logout_rounded,
+              size: 18, color: brand.textPrimary),
+          label: Text(
+            'Cerrar sesión',
+            style: AppTextStyles.ui(
+              size: 14,
+              weight: FontWeight.w600,
+              color: brand.textPrimary,
+            ),
           ),
-        );
-      },
-      child: Container(
-        child: Padding(
-          padding: const EdgeInsets.only(right: 8.0),
-          child: Column(
-            children: [
-              Image.asset(
-                asset,
-                width: 64,
-                height: 64,
-              ),
-              Text(title, style: const TextStyle(fontSize: 12)),
-            ],
+          style: OutlinedButton.styleFrom(
+            padding: const EdgeInsets.symmetric(vertical: 14),
+            side: BorderSide(color: brand.borderStrong),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(14),
+            ),
           ),
         ),
-      ),
+        const SizedBox(height: 10),
+        TextButton(
+          onPressed: onDelete,
+          child: Text(
+            'Eliminar cuenta',
+            style: AppTextStyles.ui(
+              size: 12,
+              weight: FontWeight.w600,
+              color: AppColors.mojo,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/pages/register/register.dart
+++ b/lib/ui/pages/register/register.dart
@@ -1,469 +1,826 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
 import 'package:guachinches/data/HttpRemoteRepository.dart';
 import 'package:guachinches/data/RemoteRepository.dart';
 import 'package:guachinches/globalMethods.dart';
-import 'package:guachinches/ui/pages/listas/listas_screen.dart';
 import 'package:guachinches/ui/pages/login/login.dart';
-import 'package:guachinches/ui/pages/map/map_search.dart';
-import 'package:guachinches/ui/pages/new_home/new_home_screen.dart';
-import 'package:guachinches/ui/pages/new_home/new_home_tab_scaffold.dart';
 import 'package:guachinches/ui/pages/register/register_presenter.dart';
-import 'package:guachinches/ui/pages/search_page/search_page.dart';
-import 'package:guachinches/ui/pages/splash_screen/splash_screen.dart';
-import 'package:guachinches/ui/pages/video/video.dart';
 import 'package:http/http.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class Register extends StatefulWidget {
+  const Register({Key? key}) : super(key: key);
+
   @override
-  _RegisterState createState() => _RegisterState();
+  State<Register> createState() => _RegisterState();
 }
 
-class _RegisterState extends State<Register> implements RegisterView{
+class _RegisterState extends State<Register> implements RegisterView {
   final _formKey = GlobalKey<FormState>();
-  final TextEditingController _mainPassword = TextEditingController();
-  final TextEditingController _nombre = TextEditingController();
-  final TextEditingController _apellidos = TextEditingController();
-  final TextEditingController _email = TextEditingController();
-  final TextEditingController _telefono = TextEditingController();
-  late RegisterPresenter presenter;
-  late RemoteRepository _remoteRepository;
-  String errorText = "";
-  bool checkedValue = false;
-  bool showErrorText = false;
+  final _nombre = TextEditingController();
+  final _apellidos = TextEditingController();
+  final _telefono = TextEditingController();
+  final _email = TextEditingController();
+  final _password = TextEditingController();
+  final _passwordConfirm = TextEditingController();
+
+  late final RemoteRepository _repo = HttpRemoteRepository(Client());
+  late final RegisterPresenter _presenter = RegisterPresenter(_repo, this);
+
+  bool _passwordVisible = false;
+  bool _passwordConfirmVisible = false;
+  bool _termsAccepted = false;
+  bool _termsError = false;
+  bool _loading = false;
+  String _errorText = '';
+
+  // Same regex used by the legacy form so backend validation is preserved.
+  static final RegExp _phoneRe = RegExp(r'^[6,7]{1}[0-9]{8}$');
+  static final RegExp _emailRe =
+      RegExp(r"^[\w.!#$%&'*+\-/=?^_`{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+");
+
   @override
-  void initState() {
-    _remoteRepository = HttpRemoteRepository(Client());
-    presenter = RegisterPresenter(_remoteRepository, this);
-    super.initState();
+  void dispose() {
+    _nombre.dispose();
+    _apellidos.dispose();
+    _telefono.dispose();
+    _email.dispose();
+    _password.dispose();
+    _passwordConfirm.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_loading) return;
+    FocusScope.of(context).unfocus();
+    final formValid = _formKey.currentState?.validate() == true;
+    setState(() => _termsError = !_termsAccepted);
+    if (!formValid || !_termsAccepted) return;
+
+    final data = <String, String>{
+      'nombre': _nombre.text.trim(),
+      'apellidos': _apellidos.text.trim(),
+      'email': _email.text.trim().toLowerCase(),
+      'telefono': _telefono.text.trim(),
+      'password': _password.text,
+    };
+
+    setState(() {
+      _loading = true;
+      _errorText = '';
+    });
+    await _presenter.register(data);
+    if (!mounted) return;
+    setState(() => _loading = false);
+  }
+
+  Future<void> _openUrl(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-          image: DecorationImage(
-              fit: BoxFit.cover,
-              image: AssetImage("assets/images/loginBg.png"))
-      ),
-      child: Scaffold(
-        backgroundColor: Colors.transparent,
-        body: Container(
-          padding: EdgeInsets.symmetric(horizontal: 20.0),
-          color: Colors.transparent,
-          height: MediaQuery.of(context).size.height,
-          width: MediaQuery.of(context).size.width,
-          child: SingleChildScrollView(
-            child: Column(
+    final size = MediaQuery.of(context).size;
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+
+    return Scaffold(
+      backgroundColor: AppColors.crema,
+      // Tap fuera de los textfields → cierra teclado.
+      body: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: Stack(
+        children: [
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            height: size.height * 0.32,
+            child: Stack(
+              fit: StackFit.expand,
               children: [
-                SizedBox(
-                  height: 40.0,
+                Image.asset(
+                  'assets/images/loginBg.png',
+                  fit: BoxFit.cover,
                 ),
-                GestureDetector(
-                  onTap: () => GlobalMethods().removePagesAndGoToNewScreen(
-                      context,
-                      NewHomeTabScaffold(screens: [
-                        const NewHomeScreen(),
-                        const ListasScreen(),
-                        MapSearch(),
-                        VideoScreen(index: 0),
-                        Login("Para ver tu perfíl debes iniciar sesión."),
-                      ])),
-                  child: Container(
-                    alignment: Alignment.centerRight,
-                    child: Icon(
-                      Icons.close,
-                      color: Colors.grey,
-                      size: 40.0,
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        AppColors.profundo.withOpacity(0.45),
+                        AppColors.profundo.withOpacity(0.18),
+                        AppColors.crema,
+                      ],
+                      stops: const [0.0, 0.6, 1.0],
                     ),
                   ),
                 ),
-                SizedBox(
-                  height: 30.0,
-                ),
-                Align(
-                  alignment: Alignment.topLeft,
-                  child: Text(
-                    "Registrar usuario",
-                    textAlign: TextAlign.start,
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        color: Colors.white,
-                        fontSize: 40.0,
+              ],
+            ),
+          ),
+          SafeArea(
+            child: SingleChildScrollView(
+              padding: EdgeInsets.fromLTRB(20, 8, 20, 32 + bottomInset),
+              physics: const BouncingScrollPhysics(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      _CircleIconButton(
+                        icon: Icons.arrow_back_ios_new_rounded,
+                        onTap: () => Navigator.of(context).pop(),
+                        background: Colors.white.withOpacity(0.92),
+                        foreground: AppColors.ink,
                       ),
+                    ],
                   ),
-                ),
-                SizedBox(
-                  height: 15.0,
-                ),
-                errorText == null || errorText.isEmpty ? Container() : Text(
-                  errorText,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 18.0,
+                  const SizedBox(height: 24),
+                  Text(
+                    'Crear cuenta',
+                    style: AppTextStyles.displayHero(
+                      size: 34,
+                      color: Colors.white,
+                    ).copyWith(height: 1.05),
                   ),
-                ),
-                SizedBox(
-                  height: 15.0,
-                ),
-                Form(
-                  key: _formKey,
-                  child: Column(
-                    children: <Widget>[
-                      Container(
-                        height: 62,
-                        padding: const EdgeInsets.only(left: 8.0),
-                        decoration: BoxDecoration(
-                            border: Border(
-                              left: BorderSide(width: 3.0, color: Colors.white),
-                            )
-                        ),
-                        child: TextFormField(
-                          controller: _nombre,
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return "Campo obligatorio";
-                            }
-                          },
-                          keyboardType: TextInputType.text,
-                          style: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 1),
-                              fontSize: 24.0
+                  const SizedBox(height: 6),
+                  Text(
+                    'En menos de un minuto formarás parte de la comunidad guachinche.',
+                    style: AppTextStyles.ui(
+                      size: 13,
+                      color: Colors.white.withOpacity(0.92),
+                    ).copyWith(height: 1.35),
+                  ),
+                  const SizedBox(height: 24),
+                  _Card(
+                    child: Form(
+                      key: _formKey,
+                      autovalidateMode: AutovalidateMode.onUserInteraction,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          if (_errorText.isNotEmpty)
+                            _ErrorBanner(message: _errorText),
+                          _SectionLabel(
+                            text: 'Datos personales',
+                            icon: Icons.person_outline_rounded,
                           ),
-                          decoration: InputDecoration(
-                            border: InputBorder.none,
-                            enabledBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(
-                                  color: Colors.transparent),
-                            ),
-                            focusedBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(color: Colors.transparent),
-                            ),
-                            labelText: "Nombre",
-                            labelStyle: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 0.7),
-                            ),
+                          const SizedBox(height: 12),
+                          _ModernField(
+                            controller: _nombre,
+                            label: 'Nombre',
+                            hint: 'Nombre',
+                            icon: Icons.badge_outlined,
+                            textInputAction: TextInputAction.next,
+                            autofillHints: const [AutofillHints.givenName],
+                            validator: (v) =>
+                                (v == null || v.trim().isEmpty)
+                                    ? 'Campo obligatorio'
+                                    : null,
                           ),
+                          const SizedBox(height: 14),
+                          _ModernField(
+                            controller: _apellidos,
+                            label: 'Apellidos',
+                            hint: 'Apellidos',
+                            icon: Icons.badge_outlined,
+                            textInputAction: TextInputAction.next,
+                            autofillHints: const [AutofillHints.familyName],
+                            validator: (v) =>
+                                (v == null || v.trim().isEmpty)
+                                    ? 'Campo obligatorio'
+                                    : null,
+                          ),
+                          const SizedBox(height: 22),
+                          _SectionLabel(
+                            text: 'Contacto',
+                            icon: Icons.alternate_email_rounded,
+                          ),
+                          const SizedBox(height: 12),
+                          _ModernField(
+                            controller: _email,
+                            label: 'Email',
+                            hint: 'tu@email.com',
+                            icon: Icons.alternate_email_rounded,
+                            keyboardType: TextInputType.emailAddress,
+                            textInputAction: TextInputAction.next,
+                            autofillHints: const [AutofillHints.email],
+                            validator: (v) {
+                              final value = v?.trim() ?? '';
+                              if (value.isEmpty) return 'Campo obligatorio';
+                              if (!_emailRe.hasMatch(value)) {
+                                return 'Email no válido';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 14),
+                          _ModernField(
+                            controller: _telefono,
+                            label: 'Teléfono',
+                            hint: '6XXXXXXXX',
+                            icon: Icons.phone_outlined,
+                            keyboardType: TextInputType.phone,
+                            textInputAction: TextInputAction.next,
+                            autofillHints: const [
+                              AutofillHints.telephoneNumber
+                            ],
+                            formatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                              LengthLimitingTextInputFormatter(9),
+                            ],
+                            validator: (v) {
+                              final value = v?.trim() ?? '';
+                              if (value.isEmpty) return 'Campo obligatorio';
+                              if (!_phoneRe.hasMatch(value)) {
+                                return 'Móvil inválido (9 dígitos)';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 22),
+                          _SectionLabel(
+                            text: 'Seguridad',
+                            icon: Icons.lock_outline_rounded,
+                          ),
+                          const SizedBox(height: 12),
+                          _ModernField(
+                            controller: _password,
+                            label: 'Contraseña',
+                            hint: 'Mínimo 8 caracteres',
+                            icon: Icons.lock_outline_rounded,
+                            obscure: !_passwordVisible,
+                            textInputAction: TextInputAction.next,
+                            autofillHints: const [AutofillHints.newPassword],
+                            trailing: IconButton(
+                              splashRadius: 20,
+                              icon: Icon(
+                                _passwordVisible
+                                    ? Icons.visibility_off_rounded
+                                    : Icons.visibility_rounded,
+                                size: 20,
+                                color: AppColors.inkMuted,
+                              ),
+                              onPressed: () => setState(() =>
+                                  _passwordVisible = !_passwordVisible),
+                            ),
+                            validator: (v) {
+                              if (v == null || v.length < 8) {
+                                return 'Debe tener al menos 8 caracteres';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 14),
+                          _ModernField(
+                            controller: _passwordConfirm,
+                            label: 'Repetir contraseña',
+                            hint: 'Confirmación',
+                            icon: Icons.lock_outline_rounded,
+                            obscure: !_passwordConfirmVisible,
+                            textInputAction: TextInputAction.done,
+                            autofillHints: const [AutofillHints.newPassword],
+                            trailing: IconButton(
+                              splashRadius: 20,
+                              icon: Icon(
+                                _passwordConfirmVisible
+                                    ? Icons.visibility_off_rounded
+                                    : Icons.visibility_rounded,
+                                size: 20,
+                                color: AppColors.inkMuted,
+                              ),
+                              onPressed: () => setState(() =>
+                                  _passwordConfirmVisible =
+                                      !_passwordConfirmVisible),
+                            ),
+                            onFieldSubmitted: (_) => _submit(),
+                            validator: (v) {
+                              if (v == null || v.length < 8) {
+                                return 'Debe tener al menos 8 caracteres';
+                              }
+                              if (v != _password.text) {
+                                return 'Las contraseñas no coinciden';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 18),
+                          _TermsRow(
+                            value: _termsAccepted,
+                            error: _termsError,
+                            onChanged: (v) => setState(() {
+                              _termsAccepted = v;
+                              if (v) _termsError = false;
+                            }),
+                            onOpenPrivacy: () => _openUrl(
+                                'https://www.guachinchesmodernos.com/data/dataPolicy/'),
+                            onOpenTerms: () => _openUrl(
+                                'https://www.guachinchesmodernos.com/data/terms/'),
+                          ),
+                          if (_termsError)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 6, left: 4),
+                              child: Row(
+                                children: [
+                                  const Icon(Icons.error_outline_rounded,
+                                      size: 13, color: AppColors.mojo),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    'Debes aceptar los términos para continuar.',
+                                    style: AppTextStyles.ui(
+                                      size: 11,
+                                      weight: FontWeight.w600,
+                                      color: AppColors.mojo,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          const SizedBox(height: 18),
+                          _PrimaryButton(
+                            label: 'Crear cuenta',
+                            loading: _loading,
+                            onPressed: _submit,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        '¿Ya tienes cuenta?',
+                        style: AppTextStyles.ui(
+                          size: 13,
+                          color: AppColors.inkSoft,
                         ),
                       ),
-                      SizedBox(
-                        height: 10.0,
-                      ),
-                      Container(
-                        height: 62,
-                        padding: const EdgeInsets.only(left: 8.0),
-                        decoration: BoxDecoration(
-                            border: Border(
-                              left: BorderSide(width: 3.0, color: Colors.white),
-                            )
-                        ),
-                        child: TextFormField(
-                          controller: _apellidos,
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return "Campo obligatorio";
-                            }
-                          },
-                          keyboardType: TextInputType.text,
-                          style: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 1),
-                              fontSize: 24.0
-                          ),
-                          decoration: InputDecoration(
-                            border: InputBorder.none,
-                            enabledBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(
-                                  color: Colors.transparent),
-                            ),
-                            focusedBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(color: Colors.transparent),
-                            ),
-                            labelText: "Apellidos",
-                            labelStyle: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 0.7),
-                            ),
-                          ),
-
-                        ),
-                      ),
-                      SizedBox(
-                        height: 10.0,
-                      ),
-                      Container(
-                        height: 62,
-                        padding: const EdgeInsets.only(left: 8.0),
-                        decoration: BoxDecoration(
-                            border: Border(
-                              left: BorderSide(width: 3.0, color: Colors.white),
-                            )
-                        ),
-                        child: TextFormField(
-                          controller: _telefono,
-                          validator: (value) {
-                            String pattern = r'^[6,7]{1}[0-9]{8}$';
-                            RegExp regExp = new RegExp(pattern);
-                            if (value == null || !regExp.hasMatch(value)) {
-                              return "Teléfono inválido";
-                            }
-                          },
-                          keyboardType: TextInputType.number,
-                          style: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 1),
-                              fontSize: 24.0
-                          ),
-                          decoration: InputDecoration(
-                            border: InputBorder.none,
-                            enabledBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(
-                                  color: Colors.transparent),
-                            ),
-                            focusedBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(color: Colors.transparent),
-                            ),
-                            labelText: "Teléfono",
-                            labelStyle: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 0.7),
-                            ),
-                          ),
-
-                        ),
-                      ),
-                      SizedBox(
-                        height: 10.0,
-                      ),
-                      Container(
-                        height: 62,
-                        padding: const EdgeInsets.only(left: 8.0),
-                        decoration: BoxDecoration(
-                            border: Border(
-                              left: BorderSide(width: 3.0, color: Colors.white),
-                            )
-                        ),
-                        child: TextFormField(
-                          controller: _email,
-                          validator: (value) {
-                            String pattern =
-                                r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+";
-                            RegExp regExp = new RegExp(pattern);
-                            if (value == null || !regExp.hasMatch(value)) {
-                              return "Email invalido";
-                            }
-                          },
-                          keyboardType: TextInputType.emailAddress,
-                          style: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 1),
-                              fontSize: 24.0
-                          ),
-                          decoration: InputDecoration(
-                            border: InputBorder.none,
-                            enabledBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(
-                                  color: Colors.transparent),
-                            ),
-                            focusedBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(color: Colors.transparent),
-                            ),
-                            labelText: "Email",
-                            labelStyle: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 0.7),
-                            ),
-                          ),
-
-                        ),
-                      ),
-                      SizedBox(
-                        height: 10.0,
-                      ),
-                      Container(
-                        height: 62,
-                        padding: const EdgeInsets.only(left: 8.0),
-                        decoration: BoxDecoration(
-                            border: Border(
-                              left: BorderSide(width: 3.0, color: Colors.white),
-                            )
-                        ),
-                        child: TextFormField(
-                          controller: _mainPassword,
-                          obscureText: true,
-                          validator: (value) {
-                            if (value == null || value.length < 8) {
-                              return "Debe tener al menos 8 caracteres";
-                            }
-                          },
-                          keyboardType: TextInputType.text,
-                          style: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 1),
-                              fontSize: 24.0
-                          ),
-                          decoration: InputDecoration(
-                            border: InputBorder.none,
-                            enabledBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(
-                                  color: Colors.transparent),
-                            ),
-                            focusedBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(color: Colors.transparent),
-                            ),
-                            labelText: "Contraseña",
-                            labelStyle: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 0.7),
-                            ),
-                          ),
-
-                        ),
-                      ),
-                      SizedBox(
-                        height: 10.0,
-                      ),
-                      Container(
-                        height: 62,
-                        padding: const EdgeInsets.only(left: 8.0),
-                        decoration: BoxDecoration(
-                            border: Border(
-                              left: BorderSide(width: 3.0, color: Colors.white),
-                            )
-                        ),
-                        child: TextFormField(
-                          validator: (value) {
-                            if (value == null || value.length < 8) {
-                              return "Debe tener al menos 8 caracteres";
-                            }
-                            if (value != _mainPassword.text) {
-                              return "Las contraseñas no coinciden";
-                            }
-                          },
-                          keyboardType: TextInputType.text,
-                          obscureText: true,
-                          style: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 1),
-                              fontSize: 24.0
-                          ),
-                          decoration: InputDecoration(
-                            border: InputBorder.none,
-                            enabledBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(
-                                  color: Colors.transparent),
-                            ),
-                            focusedBorder: UnderlineInputBorder(
-                              borderSide: BorderSide(color: Colors.transparent),
-                            ),
-                            labelText: "Repetir contraseña",
-                            labelStyle: TextStyle(
-                              color: Color.fromRGBO(255, 255, 255, 0.7),
-                            ),
+                      const SizedBox(width: 4),
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: Text(
+                          'Inicia sesión',
+                          style: AppTextStyles.ui(
+                            size: 13,
+                            weight: FontWeight.w800,
+                            color: AppColors.atlantico,
                           ),
                         ),
                       ),
                     ],
                   ),
-                ),
-                Row(
-
-                  children: [
-                    Container(
-                      height: 60,
-                      width: 30,
-                      child: CheckboxListTile(
-                        side: BorderSide(color: Colors.white),
-                        value: checkedValue,
-                        onChanged: (newValue) {
-                          setState(() {
-                            checkedValue = newValue!;
-                            showErrorText = !newValue;
-                          });
-                        },
-                        controlAffinity: ListTileControlAffinity.leading,  //  <-- leading Checkbox
-                      ),
-                    ),
-                    Container(
-                      width: MediaQuery.of(context).size.width * 0.6,
-                      child: RichText(
-
-                        text: TextSpan(children: [
-                          TextSpan(
-                            text: "Acepto la  ",
-                            style: new TextStyle(color: Colors.white),
-
-                          ),
-                          TextSpan(text: " protección de datos  ",    style: new TextStyle(color: Colors.white,),
-                              recognizer: TapGestureRecognizer()..onTap = (){
-                                launch('https://www.guachinchesmodernos.com/data/dataPolicy/');
-                              }
-                          ),
-                          TextSpan(text: "y los ",style: new TextStyle(color: Colors.white)),
-                          TextSpan(text: "términos y condiciones de uso  ",
-                              recognizer: TapGestureRecognizer()..onTap = (){
-                                launch('https://www.guachinchesmodernos.com/data/terms/');
-                              },
-                              style: new TextStyle(color: Colors.blue,decoration: TextDecoration.underline)),
-
-                        ]),
-                      ),
-                    )
-                  ],
-                ),
-                showErrorText ?Text("Debes aceptar los terminos y condiciones",style: TextStyle(color: Colors.white),):Container(),
-                SizedBox(
-                  height: 30.0,
-                ),
-                GestureDetector(
-                  onTap: () {
-                    if(checkedValue==false){
-                      setState(() {
-                        showErrorText = true;
-                      });
-                    }
-                    if (_formKey.currentState!.validate()&&checkedValue) {
-                      Map data = Map<String, String>();
-                      data.putIfAbsent("nombre", () => _nombre.text);
-                      data.putIfAbsent("apellidos", () => _apellidos.text);
-                      data.putIfAbsent("email", () => _email.text.toLowerCase());
-                      data.putIfAbsent("telefono", () => _telefono.text.toString());
-                      data.putIfAbsent("password", () => _mainPassword.text.toString());
-                      presenter.register(data);
-                    }
-                  },
-                  child: Container(
-                    width: double.infinity,
-                    alignment: Alignment.center,
-                    margin: EdgeInsets.symmetric(horizontal: 40.0),
-                    decoration: BoxDecoration(
-                      color: Color.fromRGBO(0, 189, 195, 1),
-                      borderRadius: BorderRadius.circular(11.0),
-                    ),
-                    padding: EdgeInsets.symmetric(vertical: 15.0),
-                    child: Text(
-                      "Registrarse",
-                      style: TextStyle(
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                          fontSize: 16.0),
-                    ),
-                  ),
-                ),
-                SizedBox(
-                  height: 30.0,
-                ),
-              ],
+                ],
+              ),
             ),
           ),
+        ],
         ),
       ),
     );
   }
 
+  // ── RegisterView ──────────────────────────────────────────────────────
   @override
   correctInsert() {
-    GlobalMethods().pushAndReplacement(context, Login('Registro con exito, inicia sesión'));
+    if (!mounted) return;
+    GlobalMethods().pushAndReplacement(
+      context,
+      const Login('Registro con éxito, inicia sesión'),
+    );
   }
 
   @override
   errorInsert(String error) {
+    if (!mounted) return;
     setState(() {
-      errorText = error;
+      _errorText = error.isEmpty ? 'No hemos podido completar el registro.' : error;
+      _loading = false;
     });
   }
 }
 
+// ── Reusable widgets (mismo estilo que Login) ──────────────────────────────
+class _Card extends StatelessWidget {
+  final Widget child;
+  const _Card({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(18, 18, 18, 16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.borderCreamMd),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.ink.withOpacity(0.06),
+            blurRadius: 24,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: child,
+    );
+  }
+}
+
+class _CircleIconButton extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback onTap;
+  final Color background;
+  final Color foreground;
+  const _CircleIconButton({
+    required this.icon,
+    required this.onTap,
+    required this.background,
+    required this.foreground,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        width: 40,
+        height: 40,
+        decoration: BoxDecoration(
+          color: background,
+          shape: BoxShape.circle,
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.ink.withOpacity(0.08),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Icon(icon, size: 18, color: foreground),
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  final IconData icon;
+  const _SectionLabel({required this.text, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 15, color: AppColors.atlantico),
+        const SizedBox(width: 8),
+        Text(
+          text.toUpperCase(),
+          style: AppTextStyles.eyebrow(
+            size: 11,
+            color: AppColors.atlantico,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ErrorBanner extends StatelessWidget {
+  final String message;
+  const _ErrorBanner({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 14),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppColors.mojo.withOpacity(0.10),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.mojo.withOpacity(0.35)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.error_outline_rounded,
+              size: 18, color: AppColors.mojo),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: AppTextStyles.ui(
+                size: 12,
+                weight: FontWeight.w600,
+                color: AppColors.mojo,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ModernField extends StatefulWidget {
+  final TextEditingController controller;
+  final String label;
+  final String hint;
+  final IconData icon;
+  final bool obscure;
+  final TextInputType? keyboardType;
+  final TextInputAction? textInputAction;
+  final List<String>? autofillHints;
+  final List<TextInputFormatter>? formatters;
+  final Widget? trailing;
+  final ValueChanged<String>? onFieldSubmitted;
+  final FormFieldValidator<String>? validator;
+
+  const _ModernField({
+    required this.controller,
+    required this.label,
+    required this.hint,
+    required this.icon,
+    this.obscure = false,
+    this.keyboardType,
+    this.textInputAction,
+    this.autofillHints,
+    this.formatters,
+    this.trailing,
+    this.onFieldSubmitted,
+    this.validator,
+  });
+
+  @override
+  State<_ModernField> createState() => _ModernFieldState();
+}
+
+class _ModernFieldState extends State<_ModernField> {
+  final FocusNode _focus = FocusNode();
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _focus.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _focus.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasError = _error != null;
+    final focused = _focus.hasFocus;
+    final borderColor = hasError
+        ? AppColors.mojo
+        : focused
+            ? AppColors.atlantico
+            : AppColors.borderCreamMd;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 4, bottom: 6),
+          child: Text(
+            widget.label.toUpperCase(),
+            style: AppTextStyles.eyebrow(
+              size: 10,
+              color: hasError
+                  ? AppColors.mojo
+                  : focused
+                      ? AppColors.atlantico
+                      : AppColors.inkMuted,
+            ),
+          ),
+        ),
+        AnimatedContainer(
+          duration: const Duration(milliseconds: 160),
+          decoration: BoxDecoration(
+            color: AppColors.crema.withOpacity(focused ? 0.55 : 0.35),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: borderColor,
+              width: focused || hasError ? 1.5 : 1,
+            ),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            children: [
+              Icon(widget.icon, size: 18, color: AppColors.inkMuted),
+              const SizedBox(width: 10),
+              Expanded(
+                child: TextFormField(
+                  controller: widget.controller,
+                  focusNode: _focus,
+                  obscureText: widget.obscure,
+                  keyboardType: widget.keyboardType,
+                  textInputAction: widget.textInputAction,
+                  autofillHints: widget.autofillHints,
+                  inputFormatters: widget.formatters,
+                  validator: (v) {
+                    final result = widget.validator?.call(v);
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      if (!mounted) return;
+                      if (_error != result) setState(() => _error = result);
+                    });
+                    return result;
+                  },
+                  onFieldSubmitted: widget.onFieldSubmitted,
+                  cursorColor: AppColors.atlantico,
+                  style: AppTextStyles.ui(
+                    size: 15,
+                    color: AppColors.ink,
+                    weight: FontWeight.w500,
+                  ),
+                  decoration: InputDecoration(
+                    isDense: true,
+                    contentPadding: const EdgeInsets.symmetric(vertical: 16),
+                    border: InputBorder.none,
+                    errorStyle: const TextStyle(height: 0, fontSize: 0),
+                    hintText: widget.hint,
+                    hintStyle: AppTextStyles.ui(
+                      size: 15,
+                      color: AppColors.inkMuted,
+                    ),
+                  ),
+                ),
+              ),
+              if (widget.trailing != null) widget.trailing!,
+            ],
+          ),
+        ),
+        if (hasError)
+          Padding(
+            padding: const EdgeInsets.only(left: 4, top: 6),
+            child: Row(
+              children: [
+                const Icon(Icons.error_outline_rounded,
+                    size: 13, color: AppColors.mojo),
+                const SizedBox(width: 4),
+                Flexible(
+                  child: Text(
+                    _error!,
+                    style: AppTextStyles.ui(
+                      size: 11,
+                      weight: FontWeight.w600,
+                      color: AppColors.mojo,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _TermsRow extends StatelessWidget {
+  final bool value;
+  final bool error;
+  final ValueChanged<bool> onChanged;
+  final VoidCallback onOpenPrivacy;
+  final VoidCallback onOpenTerms;
+
+  const _TermsRow({
+    required this.value,
+    required this.error,
+    required this.onChanged,
+    required this.onOpenPrivacy,
+    required this.onOpenTerms,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        GestureDetector(
+          onTap: () => onChanged(!value),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 140),
+            margin: const EdgeInsets.only(top: 2),
+            width: 22,
+            height: 22,
+            decoration: BoxDecoration(
+              color: value
+                  ? AppColors.atlantico
+                  : Colors.white,
+              borderRadius: BorderRadius.circular(7),
+              border: Border.all(
+                color: error
+                    ? AppColors.mojo
+                    : value
+                        ? AppColors.atlantico
+                        : AppColors.borderCreamMd,
+                width: 1.4,
+              ),
+            ),
+            child: value
+                ? const Icon(Icons.check_rounded,
+                    size: 16, color: Colors.white)
+                : null,
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(top: 1),
+            child: RichText(
+              text: TextSpan(
+                style: AppTextStyles.ui(
+                  size: 12,
+                  color: AppColors.inkSoft,
+                ).copyWith(height: 1.4),
+                children: [
+                  const TextSpan(text: 'He leído y acepto la '),
+                  TextSpan(
+                    text: 'protección de datos',
+                    style: AppTextStyles.ui(
+                      size: 12,
+                      weight: FontWeight.w700,
+                      color: AppColors.atlantico,
+                    ).copyWith(decoration: TextDecoration.underline),
+                    recognizer: TapGestureRecognizer()..onTap = onOpenPrivacy,
+                  ),
+                  const TextSpan(text: ' y los '),
+                  TextSpan(
+                    text: 'términos de uso',
+                    style: AppTextStyles.ui(
+                      size: 12,
+                      weight: FontWeight.w700,
+                      color: AppColors.atlantico,
+                    ).copyWith(decoration: TextDecoration.underline),
+                    recognizer: TapGestureRecognizer()..onTap = onOpenTerms,
+                  ),
+                  const TextSpan(text: '.'),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+  final bool loading;
+
+  const _PrimaryButton({
+    required this.label,
+    required this.onPressed,
+    this.loading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 54,
+      child: ElevatedButton(
+        onPressed: loading ? null : onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.atlantico,
+          foregroundColor: Colors.white,
+          disabledBackgroundColor: AppColors.atlantico.withOpacity(0.6),
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+        child: loading
+            ? const SizedBox(
+                width: 22,
+                height: 22,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2.4,
+                  color: Colors.white,
+                ),
+              )
+            : Text(
+                label,
+                style: AppTextStyles.ui(
+                  size: 15,
+                  weight: FontWeight.w800,
+                  color: Colors.white,
+                ),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/restaurant_detail/restaurant_detail_screen.dart
+++ b/lib/ui/pages/restaurant_detail/restaurant_detail_screen.dart
@@ -344,7 +344,11 @@ class _RestaurantDetailScreenState extends State<RestaurantDetailScreen>
             key: _reviewsKey,
             child: Padding(
               padding: const EdgeInsets.only(top: 18),
-              child: ReviewsSection(restaurant: r),
+              child: ReviewsSection(
+                restaurant: r,
+                onReviewSubmitted: () =>
+                    _presenter.getRestaurantById(widget.id),
+              ),
             ),
           ),
         ],

--- a/lib/ui/pages/restaurant_detail/widgets/reviews_section.dart
+++ b/lib/ui/pages/restaurant_detail/widgets/reviews_section.dart
@@ -1,42 +1,162 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:guachinches/config/app_colors.dart';
 import 'package:guachinches/config/brand_colors.dart';
 import 'package:guachinches/config/app_text_styles.dart';
 import 'package:guachinches/data/model/Review.dart';
 import 'package:guachinches/data/model/restaurant.dart';
+import 'package:guachinches/ui/pages/login/login.dart';
+import 'package:guachinches/ui/pages/restaurant_detail/widgets/write_review_screen.dart';
 
-class ReviewsSection extends StatelessWidget {
+class ReviewsSection extends StatefulWidget {
   final Restaurant restaurant;
+  final VoidCallback? onReviewSubmitted;
 
-  const ReviewsSection({super.key, required this.restaurant});
+  const ReviewsSection({
+    super.key,
+    required this.restaurant,
+    this.onReviewSubmitted,
+  });
+
+  @override
+  State<ReviewsSection> createState() => _ReviewsSectionState();
+}
+
+class _ReviewsSectionState extends State<ReviewsSection> {
+  static const _storage = FlutterSecureStorage();
+  String? _userId;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadUserId();
+  }
+
+  Future<void> _loadUserId() async {
+    final id = await _storage.read(key: 'userId');
+    if (!mounted) return;
+    setState(() => _userId = id);
+  }
+
+  Review? get _myReview {
+    if (_userId == null || _userId!.isEmpty) return null;
+    for (final r in widget.restaurant.valoraciones) {
+      if (r.valoracionesUsuarioId == _userId) return r;
+    }
+    return null;
+  }
+
+  Future<void> _openWriteReview(BuildContext context, {int initial = 0}) async {
+    HapticFeedback.lightImpact();
+    final userId = _userId ?? await _storage.read(key: 'userId');
+    if (!context.mounted) return;
+    if (userId == null || userId.isEmpty) {
+      _showAuthSheet(context);
+      return;
+    }
+    if (_myReview != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Ya has dejado una reseña para este restaurante.'),
+          backgroundColor: AppColors.atlanticoOscuro,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+    final result = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => WriteReviewScreen(
+          restaurant: widget.restaurant,
+          initialRating: initial,
+        ),
+      ),
+    );
+    if (result == true) {
+      widget.onReviewSubmitted?.call();
+    }
+  }
+
+  void _showAuthSheet(BuildContext context) {
+    final brand = context.brand;
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: brand.elevated,
+      isScrollControlled: false,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetCtx) => _AuthPromptSheet(
+        onLogin: () {
+          Navigator.pop(sheetCtx);
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => const Login(
+                'Inicia sesión para dejar tu reseña.',
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    final reviews = restaurant.valoraciones;
+    final reviews = widget.restaurant.valoraciones;
     final hasReviews = reviews.isNotEmpty;
     final visible = reviews.take(3).toList();
+    final myReview = _myReview;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 14),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'RESEÑAS',
-            style: AppTextStyles.displaySection(size: 11),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Text(
+                  'RESEÑAS',
+                  style: AppTextStyles.displaySection(size: 11),
+                ),
+              ),
+              if (hasReviews)
+                Text(
+                  '${reviews.length}',
+                  style: AppTextStyles.ui(
+                    size: 11,
+                    color: context.brand.textMuted,
+                    weight: FontWeight.w600,
+                  ),
+                ),
+            ],
           ),
           const SizedBox(height: 12),
+          if (hasReviews) ...[
+            _RatingSummary(restaurant: widget.restaurant),
+            const SizedBox(height: 12),
+          ],
+          if (myReview != null)
+            _AlreadyReviewedCard(review: myReview)
+          else
+            _WriteReviewPrompt(
+              onStarTap: (rating) =>
+                  _openWriteReview(context, initial: rating),
+              onTap: () => _openWriteReview(context),
+            ),
+          const SizedBox(height: 14),
           if (!hasReviews)
             Text(
-              'Aún no hay reseñas',
+              'Sé el primero en compartir tu experiencia.',
               style: AppTextStyles.ui(
-                size: 11,
+                size: 12,
                 color: context.brand.textMuted,
               ),
             )
           else ...[
-            _RatingSummary(restaurant: restaurant),
-            const SizedBox(height: 14),
             ...visible.map((r) => Padding(
                   padding: const EdgeInsets.only(bottom: 10),
                   child: _ReviewCard(review: r),
@@ -59,6 +179,271 @@ class ReviewsSection extends StatelessWidget {
                 ),
               ),
           ],
+        ],
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// CTA: tarjeta "Comparte tu experiencia" con 5 estrellas tapeables
+// ─────────────────────────────────────────────────────────────────────
+
+class _WriteReviewPrompt extends StatelessWidget {
+  final ValueChanged<int> onStarTap;
+  final VoidCallback onTap;
+
+  const _WriteReviewPrompt({
+    required this.onStarTap,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(14, 14, 14, 14),
+          decoration: BoxDecoration(
+            color: brand.surface,
+            border: Border.all(color: brand.borderStrong),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    width: 32,
+                    height: 32,
+                    decoration: BoxDecoration(
+                      color: AppColors.atlantico.withOpacity(0.15),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    alignment: Alignment.center,
+                    child: const Icon(
+                      Icons.edit_note_rounded,
+                      size: 20,
+                      color: AppColors.atlanticoClaro,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Comparte tu experiencia',
+                          style: AppTextStyles.ui(
+                            size: 14,
+                            weight: FontWeight.w700,
+                            color: brand.textPrimary,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          'Toca una estrella para empezar',
+                          style: AppTextStyles.ui(
+                            size: 11,
+                            color: brand.textMuted,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: List.generate(5, (i) {
+                  final starN = i + 1;
+                  return GestureDetector(
+                    onTap: () => onStarTap(starN),
+                    behavior: HitTestBehavior.opaque,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 4),
+                      child: Icon(
+                        Icons.star_outline_rounded,
+                        size: 32,
+                        color: brand.textMuted,
+                      ),
+                    ),
+                  );
+                }),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Bottom sheet: requiere sesión
+// ─────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────
+// Estado: el usuario ya ha dejado su reseña
+// ─────────────────────────────────────────────────────────────────────
+
+class _AlreadyReviewedCard extends StatelessWidget {
+  final Review review;
+
+  const _AlreadyReviewedCard({required this.review});
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final rating = double.tryParse(review.rating)?.round() ?? 0;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+      decoration: BoxDecoration(
+        color: brand.surface,
+        border: Border.all(color: AppColors.laurisilva.withOpacity(0.35)),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 32,
+            height: 32,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: AppColors.laurisilva.withOpacity(0.18),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: const Icon(
+              Icons.check_rounded,
+              size: 20,
+              color: AppColors.laurisilva,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Ya has reseñado este restaurante',
+                  style: AppTextStyles.ui(
+                    size: 13,
+                    weight: FontWeight.w700,
+                    color: brand.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Row(
+                  children: List.generate(5, (i) {
+                    return Padding(
+                      padding: const EdgeInsets.only(right: 2),
+                      child: Icon(
+                        i < rating ? Icons.star_rounded : Icons.star_outline_rounded,
+                        size: 13,
+                        color: AppColors.sol,
+                      ),
+                    );
+                  }),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AuthPromptSheet extends StatelessWidget {
+  final VoidCallback onLogin;
+
+  const _AuthPromptSheet({required this.onLogin});
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final bottom = MediaQuery.of(context).padding.bottom;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(20, 12, 20, 16 + bottom),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: brand.textMuted,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          Container(
+            width: 56,
+            height: 56,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: AppColors.atlantico.withOpacity(0.15),
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: const Icon(
+              Icons.lock_outline_rounded,
+              color: AppColors.atlanticoClaro,
+              size: 26,
+            ),
+          ),
+          const SizedBox(height: 14),
+          Text(
+            'Inicia sesión para dejar tu reseña',
+            textAlign: TextAlign.center,
+            style: AppTextStyles.displayHero(size: 20),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Necesitas una cuenta para puntuar y comentar restaurantes.',
+            textAlign: TextAlign.center,
+            style: AppTextStyles.ui(
+              size: 13,
+              color: brand.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 22),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.atlantico,
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14),
+              ),
+              elevation: 0,
+            ),
+            onPressed: onLogin,
+            child: Text(
+              'INICIAR SESIÓN',
+              style: AppTextStyles.displaySection(size: 12)
+                  .copyWith(color: Colors.white, letterSpacing: 1.0),
+            ),
+          ),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(
+              'Ahora no',
+              style: AppTextStyles.ui(
+                size: 13,
+                weight: FontWeight.w600,
+                color: brand.textSecondary,
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/ui/pages/restaurant_detail/widgets/write_review_screen.dart
+++ b/lib/ui/pages/restaurant_detail/widgets/write_review_screen.dart
@@ -1,0 +1,555 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/config/brand_colors.dart';
+import 'package:guachinches/data/HttpRemoteRepository.dart';
+import 'package:guachinches/data/model/restaurant.dart';
+import 'package:http/http.dart' as http;
+
+class WriteReviewScreen extends StatefulWidget {
+  final Restaurant restaurant;
+  final int initialRating;
+
+  const WriteReviewScreen({
+    super.key,
+    required this.restaurant,
+    this.initialRating = 0,
+  });
+
+  @override
+  State<WriteReviewScreen> createState() => _WriteReviewScreenState();
+}
+
+class _WriteReviewScreenState extends State<WriteReviewScreen> {
+  final _titleCtrl = TextEditingController();
+  final _reviewCtrl = TextEditingController();
+  final _reviewFocus = FocusNode();
+  final _storage = const FlutterSecureStorage();
+  late final HttpRemoteRepository _repo =
+      HttpRemoteRepository(http.Client());
+
+  late int _rating;
+  bool _submitting = false;
+
+  static const _minChars = 8;
+  static const _maxChars = 600;
+
+  @override
+  void initState() {
+    super.initState();
+    _rating = widget.initialRating.clamp(0, 5);
+    _reviewCtrl.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _reviewCtrl.dispose();
+    _reviewFocus.dispose();
+    super.dispose();
+  }
+
+  bool get _canSubmit {
+    if (_rating <= 0) return false;
+    final len = _reviewCtrl.text.trim().length;
+    // Texto opcional: vacío o ≥ _minChars; bloqueamos solo el rango 1–7.
+    return len == 0 || len >= _minChars;
+  }
+
+  Future<void> _submit() async {
+    if (!_canSubmit || _submitting) return;
+    HapticFeedback.lightImpact();
+    setState(() => _submitting = true);
+    try {
+      final userId = await _storage.read(key: 'userId');
+      if (userId == null || userId.isEmpty) {
+        if (!mounted) return;
+        Navigator.pop(context, false);
+        return;
+      }
+      final ok = await _repo.saveReview(
+        userId,
+        widget.restaurant,
+        _titleCtrl.text.trim(),
+        _reviewCtrl.text.trim(),
+        _rating.toString(),
+      );
+      if (!mounted) return;
+      if (ok) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('¡Reseña publicada!'),
+            backgroundColor: AppColors.laurisilva,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+        Navigator.pop(context, true);
+      } else {
+        setState(() => _submitting = false);
+        _showError('No se pudo publicar tu reseña. Inténtalo de nuevo.');
+      }
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      _showError('Sin conexión. Comprueba tu internet.');
+    }
+  }
+
+  void _showError(String msg) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(msg),
+        backgroundColor: AppColors.mojo,
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  String get _ratingLabel {
+    switch (_rating) {
+      case 1:
+        return 'Mala';
+      case 2:
+        return 'Regular';
+      case 3:
+        return 'Aceptable';
+      case 4:
+        return 'Muy buena';
+      case 5:
+        return 'Excelente';
+      default:
+        return 'Toca una estrella';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final r = widget.restaurant;
+
+    return Scaffold(
+      backgroundColor: brand.base,
+      appBar: AppBar(
+        backgroundColor: brand.base,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.close_rounded, color: brand.textPrimary),
+          onPressed: () => Navigator.pop(context, false),
+        ),
+        title: Text(
+          'Escribir reseña',
+          style: AppTextStyles.displaySection(size: 13),
+        ),
+        centerTitle: true,
+      ),
+      body: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: SingleChildScrollView(
+          physics: const BouncingScrollPhysics(),
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _RestaurantHeader(restaurant: r),
+              const SizedBox(height: 20),
+              _RatingPicker(
+                value: _rating,
+                label: _ratingLabel,
+                onChanged: (v) {
+                  HapticFeedback.selectionClick();
+                  setState(() => _rating = v);
+                },
+              ),
+              const SizedBox(height: 18),
+              _Field(
+                controller: _titleCtrl,
+                label: 'Título (opcional)',
+                hint: 'Ej. La mejor ropa vieja de Tenerife',
+                maxLength: 60,
+              ),
+              const SizedBox(height: 14),
+              _Field(
+                controller: _reviewCtrl,
+                focusNode: _reviewFocus,
+                label: 'Tu reseña (opcional)',
+                hint: 'Cuéntanos qué pediste, qué te gustó y qué no...',
+                maxLines: 7,
+                minLines: 5,
+                maxLength: _maxChars,
+              ),
+              const SizedBox(height: 6),
+              _CharCounter(
+                current: _reviewCtrl.text.trim().length,
+                min: _minChars,
+                max: _maxChars,
+                ratingSet: _rating > 0,
+              ),
+              const SizedBox(height: 24),
+              _SubmitButton(
+                enabled: _canSubmit && !_submitting,
+                loading: _submitting,
+                onTap: _submit,
+              ),
+              const SizedBox(height: 12),
+              Center(
+                child: Text(
+                  'Tu nombre se mostrará junto a tu reseña.',
+                  style: AppTextStyles.ui(
+                    size: 11,
+                    color: brand.textMuted,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+class _RestaurantHeader extends StatelessWidget {
+  final Restaurant restaurant;
+  const _RestaurantHeader({required this.restaurant});
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final image = restaurant.mainFoto.isNotEmpty
+        ? restaurant.mainFoto
+        : (restaurant.fotos.isNotEmpty
+            ? restaurant.fotos.first.photoUrl
+            : null);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: brand.surface,
+        border: Border.all(color: brand.borderStrong),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: SizedBox(
+              width: 52,
+              height: 52,
+              child: image != null
+                  ? Image.network(
+                      image,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => _ImageFallback(brand: brand),
+                    )
+                  : _ImageFallback(brand: brand),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'RESEÑANDO',
+                  style: AppTextStyles.eyebrow(
+                    size: 9,
+                    color: brand.textMuted,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  restaurant.nombre,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTextStyles.displayHero(size: 18),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ImageFallback extends StatelessWidget {
+  final dynamic brand;
+  const _ImageFallback({required this.brand});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: brand.elevated,
+      alignment: Alignment.center,
+      child: Icon(
+        Icons.restaurant_rounded,
+        color: brand.textMuted,
+        size: 22,
+      ),
+    );
+  }
+}
+
+class _RatingPicker extends StatelessWidget {
+  final int value;
+  final String label;
+  final ValueChanged<int> onChanged;
+
+  const _RatingPicker({
+    required this.value,
+    required this.label,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+      decoration: BoxDecoration(
+        color: brand.surface,
+        border: Border.all(color: brand.borderStrong),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        children: [
+          Text(
+            '¿CÓMO FUE TU EXPERIENCIA?',
+            style: AppTextStyles.displaySection(size: 11),
+          ),
+          const SizedBox(height: 14),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: List.generate(5, (i) {
+              final starN = i + 1;
+              final filled = starN <= value;
+              return GestureDetector(
+                onTap: () => onChanged(starN),
+                behavior: HitTestBehavior.opaque,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: AnimatedScale(
+                    scale: filled ? 1.0 : 0.92,
+                    duration: const Duration(milliseconds: 120),
+                    child: Icon(
+                      filled
+                          ? Icons.star_rounded
+                          : Icons.star_outline_rounded,
+                      size: 40,
+                      color: filled
+                          ? AppColors.sol
+                          : brand.textMuted,
+                    ),
+                  ),
+                ),
+              );
+            }),
+          ),
+          const SizedBox(height: 10),
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 150),
+            child: Text(
+              label,
+              key: ValueKey(label),
+              style: AppTextStyles.ui(
+                size: 12,
+                weight: FontWeight.w600,
+                color: value > 0
+                    ? AppColors.sol
+                    : brand.textMuted,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Field extends StatelessWidget {
+  final TextEditingController controller;
+  final FocusNode? focusNode;
+  final String label;
+  final String hint;
+  final int maxLines;
+  final int? minLines;
+  final int? maxLength;
+
+  const _Field({
+    required this.controller,
+    this.focusNode,
+    required this.label,
+    required this.hint,
+    this.maxLines = 1,
+    this.minLines,
+    this.maxLength,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label.toUpperCase(),
+          style: AppTextStyles.eyebrow(
+            size: 10,
+            color: brand.textSecondary,
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: controller,
+          focusNode: focusNode,
+          maxLines: maxLines,
+          minLines: minLines,
+          maxLength: maxLength,
+          cursorColor: AppColors.atlantico,
+          style: AppTextStyles.ui(
+            size: 14,
+            color: brand.textPrimary,
+          ),
+          decoration: InputDecoration(
+            hintText: hint,
+            hintStyle: AppTextStyles.ui(
+              size: 14,
+              color: brand.textMuted,
+            ),
+            counterText: '',
+            filled: true,
+            fillColor: brand.surface,
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(color: brand.borderStrong),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide(color: brand.borderStrong),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide:
+                  const BorderSide(color: AppColors.atlantico, width: 1.4),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CharCounter extends StatelessWidget {
+  final int current;
+  final int min;
+  final int max;
+  final bool ratingSet;
+
+  const _CharCounter({
+    required this.current,
+    required this.min,
+    required this.max,
+    required this.ratingSet,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final empty = current == 0;
+    final tooShort = !empty && current < min;
+    final ok = ratingSet && (empty || current >= min);
+
+    String label;
+    Color color;
+    if (tooShort) {
+      label = 'Mínimo $min caracteres si escribes algo';
+      color = AppColors.mojo;
+    } else if (!ratingSet) {
+      label = 'Selecciona una valoración';
+      color = brand.textMuted;
+    } else if (ok && empty) {
+      label = 'Listo para publicar (texto opcional)';
+      color = AppColors.laurisilva;
+    } else {
+      label = 'Listo para publicar';
+      color = AppColors.laurisilva;
+    }
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Flexible(
+          child: Text(
+            label,
+            style: AppTextStyles.ui(
+              size: 11,
+              color: color,
+              weight: FontWeight.w600,
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          '$current / $max',
+          style: AppTextStyles.ui(
+            size: 11,
+            color: brand.textMuted,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SubmitButton extends StatelessWidget {
+  final bool enabled;
+  final bool loading;
+  final VoidCallback onTap;
+
+  const _SubmitButton({
+    required this.enabled,
+    required this.loading,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.atlantico,
+          disabledBackgroundColor: AppColors.atlantico.withOpacity(0.35),
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+          elevation: 0,
+        ),
+        onPressed: enabled ? onTap : null,
+        child: loading
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2.2,
+                  valueColor: AlwaysStoppedAnimation(Colors.white),
+                ),
+              )
+            : Text(
+                'PUBLICAR RESEÑA',
+                style: AppTextStyles.displaySection(size: 12)
+                    .copyWith(color: Colors.white, letterSpacing: 1.0),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/splash_screen/splash_screen.dart
+++ b/lib/ui/pages/splash_screen/splash_screen.dart
@@ -6,7 +6,7 @@ import 'package:guachinches/data/RemoteRepository.dart';
 import 'package:guachinches/data/cubit/user/user_cubit.dart';
 import 'package:guachinches/globalMethods.dart';
 import 'package:guachinches/ui/pages/new_home/new_home_tab_scaffold.dart';
-import 'package:guachinches/ui/pages/onBoarding/on_boarding.dart';
+import 'package:guachinches/ui/pages/onboarding_flow/onboarding_flow_screen.dart';
 import 'package:guachinches/ui/pages/splash_screen/splash_screen_presenter.dart';
 import 'package:guachinches/ui/pages/surveyDetails/surveyDetails.dart';
 import 'package:guachinches/ui/pages/survey_onboarding/surveyOnboarding.dart';
@@ -68,7 +68,7 @@ class _SplashScreenState extends State<SplashScreen>
   }
   @override
   goToOnBoarding() {
-    GlobalMethods().pushAndReplacement(context, OnBoarding());
+    GlobalMethods().pushAndReplacement(context, const OnboardingFlow());
   }
 
   @override

--- a/lib/ui/pages/splash_screen/splash_screen_presenter.dart
+++ b/lib/ui/pages/splash_screen/splash_screen_presenter.dart
@@ -10,8 +10,8 @@ import 'package:guachinches/ui/pages/login/login.dart';
 import 'package:guachinches/ui/pages/map/map_search.dart';
 import 'package:guachinches/ui/pages/listas/listas_screen.dart';
 import 'package:guachinches/ui/pages/new_home/new_home_screen.dart';
+import 'package:guachinches/ui/pages/discover/discover_screen.dart';
 import 'package:guachinches/ui/pages/profile/profile_v2.dart';
-import '../video/video.dart';
 
 class SplashScreenPresenter {
   final SplashScreenView _view;
@@ -41,16 +41,16 @@ class SplashScreenPresenter {
         Login("Para ver tu perfíl debes iniciar sesión.");
     try {
       String? userId = await storage.read(key: "userId");
-      if (userId != null) {
+      if (userId != null && userId.isNotEmpty) {
+        // Sesión persistida: mostramos el perfil sin gatear en el cubit.
+        // Si el fetch falla (timeout, red), Profilev2 reintenta por su cuenta;
+        // NO borramos el userId — eso causaba "logout" al hacer hot restart
+        // con red lenta.
+        profileTab = Profilev2();
         if (_userCubit.state is UserInitial) {
-          var response = await _userCubit.getUserInfo(userId);
-          if (response == true) {
-            profileTab = Profilev2();
-          } else {
-            await storage.delete(key: "userId");
-          }
-        } else if (_userCubit.state is UserLoaded) {
-          profileTab = Profilev2();
+          // Disparamos el fetch en background para precargar el cubit.
+          // ignore: unawaited_futures
+          _userCubit.getUserInfo(userId);
         }
       }
     } catch (_) {}
@@ -58,7 +58,7 @@ class SplashScreenPresenter {
       const NewHomeScreen(),
       const ListasScreen(),
       MapSearch(),
-      VideoScreen(index: 0),
+      const DiscoverScreen(),
       profileTab,
     ];
   }
@@ -94,13 +94,10 @@ class SplashScreenPresenter {
         _view.goToOnBoarding();
       }else{
         if(key == 'true'){
-          final surveyShown = await storage.read(key: 'surveyOnboarding2026Shown');
-          if (surveyShown == null || surveyShown.isEmpty) {
-            final screens = await _buildScreens();
-            _view.goToSurveyOnboarding(screens);
-          } else {
-            mainFunction();
-          }
+          // Premios Donde Comer Canarias 2026 — pausado.
+          // Restaurar leyendo 'surveyOnboarding2026Shown' y llamando a
+          // goToSurveyOnboarding() cuando esté vacío, como antes.
+          mainFunction();
         }else{
           _view.goToOnBoarding();
         }

--- a/lib/ui/pages/valoraciones/valoraciones.dart
+++ b/lib/ui/pages/valoraciones/valoraciones.dart
@@ -1,181 +1,381 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_rating_bar/flutter_rating_bar.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/config/brand_colors.dart';
 import 'package:guachinches/data/HttpRemoteRepository.dart';
 import 'package:guachinches/data/RemoteRepository.dart';
 import 'package:guachinches/data/cubit/user/user_cubit.dart';
 import 'package:guachinches/data/cubit/user/user_state.dart';
+import 'package:guachinches/data/model/user_info.dart';
 import 'package:guachinches/globalMethods.dart';
 import 'package:guachinches/ui/pages/login/login.dart';
+import 'package:guachinches/ui/pages/restaurant_detail/restaurant_detail_screen.dart';
 import 'package:guachinches/ui/pages/valoraciones/valoraciones_presenter.dart';
 import 'package:http/http.dart';
 
 class ValoracionesPage extends StatefulWidget {
+  const ValoracionesPage({super.key});
+
   @override
-  _ValoracionesPageState createState() => _ValoracionesPageState();
+  State<ValoracionesPage> createState() => _ValoracionesPageState();
 }
 
-class _ValoracionesPageState extends State<ValoracionesPage> implements ValoracionesView{
+class _ValoracionesPageState extends State<ValoracionesPage>
+    implements ValoracionesView {
   late RemoteRepository _remoteRepository;
   late ValoracionesPresenter _presenter;
+
   @override
   void initState() {
+    super.initState();
     _remoteRepository = HttpRemoteRepository(Client());
     final userCubit = context.read<UserCubit>();
     _presenter = ValoracionesPresenter(this, _remoteRepository, userCubit);
     _presenter.isUserLogged();
-    super.initState();
   }
+
   @override
   Widget build(BuildContext context) {
+    final brand = context.brand;
     return Scaffold(
-      body: CupertinoPageScaffold(
-        child: CustomScrollView(
-          slivers: [
-            const CupertinoSliverNavigationBar(
-              backgroundColor: Color.fromRGBO(25, 27, 32, 1),
-              leading: Icon(Icons.arrow_back_ios, color: Colors.white,size: 24,),
-              largeTitle: Text('Valoraciones', style: TextStyle(color: Colors.white),),
-            ),
-            SliverFillRemaining(
-              child: Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: [
-                    BlocBuilder<UserCubit, UserState>(
-                        builder: (context, state){
-                          if(state is UserLoaded){
-                            return  Column(children:
-                            state.user.valoraciones.map((e) => Padding(
-                              padding: EdgeInsets.only(top:8.0),
-                              child: Container(
-                                padding: EdgeInsets.all(20.0),
-                                margin: EdgeInsets.symmetric(horizontal: 10.0),
-                                decoration: BoxDecoration(
-                                  color: Colors.white,
-                                  boxShadow: [
-                                    BoxShadow(
-                                        color: Colors.grey[100]!,
-                                        spreadRadius: 1.0,
-                                        offset: Offset(2.0, 1.0))
-                                  ],
-                                  borderRadius: BorderRadius.circular(17.0),
-                                ),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Row(
-                                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      children: [
-                                        Flexible(
-                                          child: Column(
-                                            crossAxisAlignment: CrossAxisAlignment.start,
-                                            children: [
-                                              Text(
-                                                e.title != null && e.title.isNotEmpty ? e.title : "Tu valoración",
-                                                style: TextStyle(
-                                                  color: Colors.black,
-                                                  fontWeight: FontWeight.bold,
-                                                  fontFamily: 'SF Pro Display',
-                                                  fontSize: 16.0,
-                                                ),
-                                              ),
-                                              Row(
-                                                children: [
-                                                  Text(
-                                                    e.rating,
-                                                    style: TextStyle(
-                                                      fontSize: 18.0,
-                                                      fontWeight: FontWeight.bold,
-                                                      fontFamily: 'SF Pro Display',
-                                                      color: Colors.black,
-                                                    ),
-                                                  ),
-                                                  RatingBar.builder(
-                                                    ignoreGestures: true,
-                                                    initialRating: double.parse(e.rating),
-                                                    minRating: 1,
-                                                    direction: Axis.horizontal,
-                                                    allowHalfRating: true,
-                                                    itemCount: 5,
-                                                    itemSize: 20,
-                                                    glowColor: Colors.white,
-                                                    onRatingUpdate: (rating)=>{},
-                                                    itemPadding: EdgeInsets.symmetric(horizontal: 2.0),
-                                                    itemBuilder: (context, _) => Icon(
-                                                      Icons.star,
-                                                      color: Colors.amber,
-                                                    ),
-                                                  ),
-                                                ],
-                                              ),
-                                            ],
-                                          ),
-                                        ),
-                                        Flexible(
-                                          child: Column(
-                                            crossAxisAlignment: CrossAxisAlignment.end,
-                                            children: [
-                                              SizedBox(
-                                                height: 5.0,
-                                              ),
-                                              Container(
-                                                child: Text(
-                                                  e.restaurantes!.nombre,
-                                                  textAlign: TextAlign.end,
-                                                  style: TextStyle(
-
-                                                      color: Colors.black,
-                                                      fontFamily: 'SF Pro Display',
-                                                      fontSize: 14.0,
-                                                      fontWeight: FontWeight.bold
-                                                  ),
-                                                ),
-                                              ),
-                                            ],
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                    SizedBox(
-                                      height: 20.0,
-                                    ),
-                                    Text(
-                                      e.review != null ? e.review : "",
-                                      style: TextStyle(
-                                        color: Colors.black,
-                                        fontSize: 14.0,
-                                      ),
-                                    ),
-                                    SizedBox(
-                                      height: 20.0,
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            )).toList());
-                          }else{
-                            return Container();
-                          }
-                        }
-                    ),
-                    SizedBox(height: 20.0),
-                  ],
+      backgroundColor: brand.base,
+      appBar: AppBar(
+        backgroundColor: brand.base,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back_rounded, color: brand.textPrimary),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(
+          'Mis valoraciones',
+          style: AppTextStyles.displaySection(size: 13),
+        ),
+        centerTitle: true,
+      ),
+      body: BlocBuilder<UserCubit, UserState>(
+        builder: (context, state) {
+          if (state is! UserLoaded) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final reviews = state.user.valoraciones;
+          if (reviews.isEmpty) {
+            return _EmptyState();
+          }
+          return ListView(
+            physics: const BouncingScrollPhysics(),
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+            children: [
+              _StatsHeader(user: state.user),
+              const SizedBox(height: 14),
+              ...reviews.map(
+                (v) => Padding(
+                  padding: const EdgeInsets.only(bottom: 10),
+                  child: _ValoracionCard(valoracion: v),
                 ),
               ),
-            )
-          ],
-        )
+            ],
+          );
+        },
       ),
     );
   }
 
   @override
   goToLogin() {
-    GlobalMethods().pushPage(context, Login("Inicia sesion para ver tus valoraciones"));
+    GlobalMethods()
+        .pushPage(context, Login('Inicia sesión para ver tus valoraciones'));
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+class _StatsHeader extends StatelessWidget {
+  final UserInfo user;
+
+  const _StatsHeader({required this.user});
+
+  double get _avgGiven {
+    final list = user.valoraciones;
+    if (list.isEmpty) return 0;
+    double sum = 0;
+    int n = 0;
+    for (final v in list) {
+      final r = double.tryParse(v.rating);
+      if (r != null) {
+        sum += r;
+        n++;
+      }
+    }
+    return n == 0 ? 0 : sum / n;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final total = user.valoraciones.length;
+    final avg = _avgGiven;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+      decoration: BoxDecoration(
+        color: brand.surface,
+        border: Border.all(color: brand.borderStrong),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: _Stat(
+              value: '$total',
+              label: total == 1 ? 'reseña' : 'reseñas',
+              icon: Icons.rate_review_rounded,
+              accent: AppColors.atlanticoClaro,
+            ),
+          ),
+          Container(width: 1, height: 36, color: brand.borderStrong),
+          Expanded(
+            child: _Stat(
+              value: avg > 0 ? avg.toStringAsFixed(1) : '—',
+              label: 'media dada',
+              icon: Icons.star_rounded,
+              accent: AppColors.sol,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Stat extends StatelessWidget {
+  final String value;
+  final String label;
+  final IconData icon;
+  final Color accent;
+
+  const _Stat({
+    required this.value,
+    required this.label,
+    required this.icon,
+    required this.accent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, size: 16, color: accent),
+            const SizedBox(width: 4),
+            Text(
+              value,
+              style: AppTextStyles.displayHero(size: 22),
+            ),
+          ],
+        ),
+        const SizedBox(height: 2),
+        Text(
+          label,
+          style: AppTextStyles.ui(
+            size: 11,
+            color: brand.textMuted,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+class _ValoracionCard extends StatelessWidget {
+  final Valoraciones valoracion;
+
+  const _ValoracionCard({required this.valoracion});
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    final ratingNum = double.tryParse(valoracion.rating)?.round() ?? 0;
+    final restaurantName = valoracion.restaurantes?.nombre ?? 'Restaurante';
+    final restaurantId = valoracion.restaurantes?.id ?? '';
+    final hasReview = valoracion.review.trim().isNotEmpty;
+    final hasTitle = valoracion.title.trim().isNotEmpty;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: restaurantId.isEmpty
+            ? null
+            : () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        RestaurantDetailScreen(id: restaurantId),
+                  ),
+                ),
+        borderRadius: BorderRadius.circular(14),
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(14, 12, 14, 14),
+          decoration: BoxDecoration(
+            color: brand.surface,
+            border: Border.all(color: brand.borderStrong),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Container(
+                    width: 36,
+                    height: 36,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: AppColors.atlantico.withOpacity(0.15),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: const Icon(
+                      Icons.restaurant_rounded,
+                      size: 18,
+                      color: AppColors.atlanticoClaro,
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          restaurantName,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTextStyles.displayHero(size: 16),
+                        ),
+                        const SizedBox(height: 4),
+                        Row(
+                          children: [
+                            ...List.generate(5, (i) {
+                              return Icon(
+                                i < ratingNum
+                                    ? Icons.star_rounded
+                                    : Icons.star_outline_rounded,
+                                size: 13,
+                                color: AppColors.sol,
+                              );
+                            }),
+                            const SizedBox(width: 6),
+                            Text(
+                              valoracion.rating,
+                              style: AppTextStyles.ui(
+                                size: 11,
+                                weight: FontWeight.w700,
+                                color: brand.textSecondary,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  Icon(
+                    Icons.chevron_right_rounded,
+                    color: brand.textMuted,
+                    size: 22,
+                  ),
+                ],
+              ),
+              if (hasTitle || hasReview) ...[
+                const SizedBox(height: 12),
+                Container(
+                  padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
+                  decoration: BoxDecoration(
+                    color: brand.elevated,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (hasTitle)
+                        Text(
+                          valoracion.title,
+                          style: AppTextStyles.ui(
+                            size: 13,
+                            weight: FontWeight.w700,
+                            color: brand.textPrimary,
+                          ),
+                        ),
+                      if (hasTitle && hasReview) const SizedBox(height: 4),
+                      if (hasReview)
+                        Text(
+                          valoracion.review,
+                          style: AppTextStyles.editorial(
+                            size: 13,
+                            color: brand.textSecondary,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+class _EmptyState extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final brand = context.brand;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 88,
+              height: 88,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: AppColors.sol.withOpacity(0.15),
+                borderRadius: BorderRadius.circular(24),
+              ),
+              child: const Icon(
+                Icons.star_outline_rounded,
+                size: 38,
+                color: AppColors.sol,
+              ),
+            ),
+            const SizedBox(height: 18),
+            Text(
+              'Aún no has valorado ningún sitio',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.displayHero(size: 22),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Cuando dejes una reseña en un restaurante, aparecerá aquí.',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.ui(
+                size: 13,
+                color: brand.textSecondary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/utils/contextual_pool.dart
+++ b/lib/utils/contextual_pool.dart
@@ -1,0 +1,105 @@
+/// Filtros contextuales que alinean la lista de "HOY EN..." con el copy
+/// del HourAwareBanner. Si el banner dice "Terrazas con atardecer", el
+/// pool solo debe traer locales con la categoría Terraza / Con vistas.
+///
+/// Las constantes son IDs de Postgres del backend de Guachinches; si el
+/// backend reasigna IDs hay que actualizarlas aquí.
+class RestaurantTypeIds {
+  static const tascas = 'ce25663d-4916-43e9-9918-c2a07b32347f';
+  static const bodegones = '7bfec60c-b55f-4d7e-9f48-1769a70dc597';
+  static const cofradia = '111ed407-296c-4b36-a29c-ecf656dddb55';
+  static const loungeTenerife = '20fab1aa-23b1-4318-942a-7bbafd6be8d6';
+  static const guachinchesModernos = '82054a45-6db3-4931-bb17-4aba588445e4';
+  static const guachinchesTradicionales =
+      '8ea45515-8a14-4638-9560-80a6446c129f';
+  static const restaurantes = '459517f7-1417-4829-bc4d-fdae09753371';
+  static const barCafeteria = '954e8bbd-ac85-45d3-acf2-353b3c853225';
+}
+
+class CategoryIds {
+  static const zonaInfantil = 'bafaae21-3839-42ca-b5bf-32467d69c8f6';
+  static const permiteMascotas = '4e14825a-eeeb-46c6-a098-0a49e0bef851';
+  static const sinGluten = '0571cc02-2c8e-4c5e-982d-ecfd703e9899';
+  static const accesoPmr = '9126ff4f-eef8-4c19-a21c-68f3995f6bf0';
+  static const carneCabra = '4e5ab5e0-fd6f-43b4-898c-27398c53a51b';
+  static const cochinoNegro = 'f5702f43-609c-4644-98d0-ce2dde8b0b87';
+  static const animales = 'd748d060-c6b3-41ee-93fa-24b60da49913';
+  static const datafono = '45632dcb-76a2-4e8b-9375-a840f342669c';
+  static const terraza = 'ebbc3752-04e1-4b41-8a92-5c129849cc0b';
+  static const conV = '11a5f3a4-3ce3-48bb-9749-03eac640e23e';
+  static const papasPinasCostillas = 'ad6e2ada-0259-4578-b67e-970846c93f74';
+  static const pescadoMarisco = 'fb5341c4-33d1-4e5c-b759-f25494459b5d';
+  static const puchero = 'c0d8085a-5a17-482c-b7cc-c4b27b09229c';
+  static const cosechaPropia = '980c2236-4e60-48c0-bc39-83117dcfad8e';
+  static const conVistas = 'de73bfc5-641f-4796-960b-ae75583b8d24';
+}
+
+/// Filtro temático asociado a un slot horario.
+class ContextualFilter {
+  /// Cualquiera de estos types vale (OR entre sí).
+  final Set<String> typeIds;
+
+  /// Al menos una de estas categorías debe estar presente (OR entre sí).
+  final Set<String> categoryIds;
+
+  const ContextualFilter({
+    this.typeIds = const {},
+    this.categoryIds = const {},
+  });
+
+  bool get isEmpty => typeIds.isEmpty && categoryIds.isEmpty;
+}
+
+/// Devuelve el filtro temático que cuadra con el copy del HourAwareBanner.
+///
+/// Mapeo:
+///   7-11  Desayunos             → Bar/Cafetería
+///   13    Menú · cierra en 1h   → Restaurantes / Tascas / Bodegones / Guachinches
+///   14-16 Sobremesa             → ídem
+///   17-19 Terrazas con atardecer → categorías Terraza / Con vistas
+///   20+   Cenas                 → Restaurantes / Tascas / Bodegones / Modernos / Lounge
+///   resto Madrugada             → sin filtro extra
+ContextualFilter contextualFilterFor(int hour) {
+  if (hour >= 7 && hour <= 11) {
+    return const ContextualFilter(
+      typeIds: {RestaurantTypeIds.barCafeteria},
+    );
+  }
+  if (hour == 13 || (hour >= 14 && hour <= 16)) {
+    return const ContextualFilter(
+      typeIds: {
+        RestaurantTypeIds.restaurantes,
+        RestaurantTypeIds.tascas,
+        RestaurantTypeIds.bodegones,
+        RestaurantTypeIds.guachinchesTradicionales,
+        RestaurantTypeIds.guachinchesModernos,
+      },
+    );
+  }
+  if (hour >= 17 && hour <= 19) {
+    // Idealmente filtraríamos por categoría Terraza / Con vistas, pero
+    // el endpoint /restaurant/pagination no devuelve `categoriasRestaurantes`
+    // (ver migration-backend/2026-add-categorias-to-pagination.md). Como
+    // workaround usamos los types más asociados con terraza/vistas.
+    return const ContextualFilter(
+      typeIds: {
+        RestaurantTypeIds.loungeTenerife,
+        RestaurantTypeIds.cofradia,
+        RestaurantTypeIds.bodegones,
+      },
+    );
+  }
+  if (hour >= 20) {
+    return const ContextualFilter(
+      typeIds: {
+        RestaurantTypeIds.restaurantes,
+        RestaurantTypeIds.tascas,
+        RestaurantTypeIds.bodegones,
+        RestaurantTypeIds.guachinchesModernos,
+        RestaurantTypeIds.loungeTenerife,
+        RestaurantTypeIds.cofradia,
+      },
+    );
+  }
+  return const ContextualFilter();
+}

--- a/migration-backend/2026-add-categorias-to-pagination.md
+++ b/migration-backend/2026-add-categorias-to-pagination.md
@@ -1,0 +1,107 @@
+# Backend migration · Incluir `categoriasRestaurantes` en `/restaurant/pagination`
+
+**Solicitado por**: app mobile (Flutter)
+**Fecha**: 2026-05-09
+**Repo afectado**: backend (NestJS + PostgreSQL)
+**Endpoint**: `GET /restaurant/pagination?from=N&island=...`
+
+## Contexto
+
+La home del mobile carga el pool de restaurantes via `restaurant/pagination`. La sección "HOY EN..." muestra cards alineadas con un banner contextual por hora ("Desayunos", "Terrazas con atardecer", "Cenas"…). El filtro temático que cuadra el copy con la lista vive en `lib/utils/contextual_pool.dart` (mobile) y se apoya en dos campos del modelo `Restaurant`:
+
+- `restaurantTypeId` ✅ **viene** en el response actual
+- `categoriasRestaurantes` ❌ **no viene** — el array se devuelve siempre vacío
+
+Verificado en runtime con un pool de 269 restaurantes (Tenerife): 0 / 112 abiertos llevan `categoriasRestaurantes` poblado, mientras que los `restaurantTypeId` sí están todos presentes.
+
+## Impacto en mobile
+
+Sin las categorías, el slot horario "Terrazas con atardecer" (17-19h) no puede filtrar por `Terraza` (`ebbc3752-04e1-4b41-8a92-5c129849cc0b`) ni `Con vistas` (`de73bfc5-641f-4796-960b-ae75583b8d24`). Como workaround temporal mobile filtra por type (`Lounge Tenerife`, `Cofradia`, `Bodegones`) lo cual es una aproximación pobre — un guachinche tradicional con buena terraza queda fuera, por ejemplo.
+
+Otras secciones del producto (filtros avanzados, badges en cards de listas curadas, recomendaciones de "perfecto para mascotas / sin gluten / con zona infantil") tampoco se pueden hacer hasta tener categorías en el pool.
+
+## Cambio solicitado
+
+Incluir el array `categoriasRestaurantes` con sus relaciones `categorias` en el response del endpoint paginado, igual que ya se hace en `GET /restaurant/:id`.
+
+### Response actual (resumido)
+
+```json
+{
+  "restaurants": [
+    {
+      "id": "...",
+      "nombre": "...",
+      "restaurantTypeId": "459517f7-1417-4829-bc4d-fdae09753371",
+      "horarios": "...",
+      "horariosJson": { ... },
+      "fotos": [ ... ],
+      "menus": [ ... ]
+      // ❌ falta categoriasRestaurantes
+    }
+  ]
+}
+```
+
+### Response esperado
+
+```json
+{
+  "restaurants": [
+    {
+      "id": "...",
+      "nombre": "...",
+      "restaurantTypeId": "459517f7-1417-4829-bc4d-fdae09753371",
+      "categoriasRestaurantes": [
+        {
+          "id": "...",
+          "categorias_restauranteId": "...",
+          "categoriaId": "ebbc3752-04e1-4b41-8a92-5c129849cc0b",
+          "categorias": {
+            "id": "ebbc3752-04e1-4b41-8a92-5c129849cc0b",
+            "nombre": "Terraza"
+          }
+        }
+      ],
+      "horarios": "...",
+      "horariosJson": { ... }
+    }
+  ]
+}
+```
+
+## Sugerencia de implementación (NestJS / TypeORM)
+
+En el servicio que resuelve `restaurant/pagination`, añadir el join con la relación `categoriasRestaurantes` y dentro su `categorias`:
+
+```ts
+// restaurant.service.ts
+this.repo.find({
+  relations: {
+    categoriasRestaurantes: {
+      categorias: true,
+    },
+    // ...resto de relaciones que ya cargas (fotos, menus, etc.)
+  },
+  // ...filtros existentes
+});
+```
+
+Si el modelo expone otro nombre de relación, mantener la misma forma de respuesta (`categoriasRestaurantes` array con `categorias` anidado) para no romper el parser actual de mobile (`lib/data/model/CategoryRestaurant.dart`).
+
+## Coste / riesgo
+
+- N+1 queries: usar `leftJoinAndSelect` o `relations` carga eager — verificar que el response no se infla demasiado para listados de 200+ restaurantes.
+- Tamaño del payload: añade ~5-10 categorías por restaurante. Si preocupa, devolver solo los `categoriaId`s (sin el objeto `categorias` completo) y cachear el catálogo de categorías en mobile.
+
+## Cuando esté en producción
+
+En mobile revertir `contextualFilterFor(17-19)` para volver a usar el filtro por categoría:
+
+```dart
+if (hour >= 17 && hour <= 19) {
+  return const ContextualFilter(
+    categoryIds: { CategoryIds.terraza, CategoryIds.conVistas },
+  );
+}
+```


### PR DESCRIPTION
## Summary
- New screens: **discover**, **onboarding flow**, **write review**
- **Weather overlay** system (clouds, rain, weather layer) + WeatherService
- **Contextual restaurant pool** (`lib/utils/contextual_pool.dart`) so the home banner copy ("Desayunos", "Terrazas con atardecer", "Cenas") aligns with the cards shown
- **Map style** customization (`lib/ui/pages/map/map_style.dart`)
- Polish across login, register, splash, listas, profile, favoritos, valoraciones, restaurant detail, new_home, advanced search, home
- Local repository updates (`local_repository`, `restaurant_sql_lite`, `sql_lite_local_repository`)
- Backend coordination doc requesting `categoriasRestaurantes` in `/restaurant/pagination` (`migration-backend/`)

## Test plan
- [ ] App boots through splash → onboarding → home without regressions
- [ ] Discover screen lists, filters and sorts visits correctly
- [ ] Weather overlay (clouds/rain) renders on home depending on conditions
- [ ] Contextual home banner copy matches the cards in the slot for the current hour
- [ ] Map screen renders with the new style and clusters interact correctly
- [ ] Write-review flow submits and reflects in reviews_section
- [ ] Login / register / profile / favoritos / valoraciones flows still work end-to-end
- [ ] No iOS regen artifacts leaked into the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)