### PR TITLE
feat(home): callout abiertos AHORA + banner ubicación + card sección …

### DIFF
--- a/lib/data/HttpRemoteRepository.dart
+++ b/lib/data/HttpRemoteRepository.dart
@@ -422,7 +422,11 @@ class HttpRemoteRepository implements RemoteRepository {
     String url = dotenv.env['ENDPOINT_V2']! + "version";
     try {
       var uri = Uri.parse(url);
-      var response = await _client.get(uri);
+      // Timeout duro de 6s: si el backend no responde en ese plazo, el
+      // splash NO debe colgarse — caemos al fallback en el caller.
+      var response = await _client
+          .get(uri)
+          .timeout(const Duration(seconds: 6));
       Version data = Version.fromJson(json.decode(response.body));
       return data;
     } on Exception catch (e) {

--- a/lib/data/cubit/location/location_cubit.dart
+++ b/lib/data/cubit/location/location_cubit.dart
@@ -6,18 +6,27 @@ import 'location_state.dart';
 class LocationCubit extends Cubit<LocationState> {
   LocationCubit() : super(LocationInitial());
 
-  /// Called once on app start. May show the system permission dialog.
+  /// Llamado al arranque y cuando el usuario tap el banner / botón "Activar".
+  /// Puede disparar el modal nativo de iOS si el permiso aún no fue rechazado
+  /// permanentemente.
   Future<void> requestLocation() async {
     try {
       final serviceEnabled = await Geolocator.isLocationServiceEnabled();
       if (!serviceEnabled) {
-        emit(LocationDenied());
+        emit(LocationServiceDisabled());
         return;
       }
 
       LocationPermission permission = await Geolocator.checkPermission();
+      // `denied` puede pedirse de nuevo. `deniedForever` no — iOS ignora
+      // el request y devuelve el mismo valor sin mostrar modal.
       if (permission == LocationPermission.denied) {
         permission = await Geolocator.requestPermission();
+      }
+
+      if (permission == LocationPermission.deniedForever) {
+        emit(LocationPermanentlyDenied());
+        return;
       }
 
       final granted = permission == LocationPermission.always ||
@@ -34,9 +43,18 @@ class LocationCubit extends Cubit<LocationState> {
     }
   }
 
-  /// Called every time the app resumes. Never shows any system dialog.
+  /// Llamado al resume de la app. Nunca muestra modal del sistema. Si el
+  /// usuario activó el permiso en Ajustes y volvió, recogemos el cambio.
   Future<void> checkLocationSilently() async {
     try {
+      final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        if (state is! LocationServiceDisabled) {
+          emit(LocationServiceDisabled());
+        }
+        return;
+      }
+
       final permission = await Geolocator.checkPermission();
       final granted = permission == LocationPermission.always ||
           permission == LocationPermission.whileInUse;
@@ -44,7 +62,9 @@ class LocationCubit extends Cubit<LocationState> {
       if (granted && state is! LocationLoaded && state is! LocationLoading) {
         await _fetchAndEmitLocation();
       } else if (!granted && state is LocationLoaded) {
-        emit(LocationDenied());
+        emit(permission == LocationPermission.deniedForever
+            ? LocationPermanentlyDenied()
+            : LocationDenied());
       }
     } catch (_) {}
   }

--- a/lib/data/cubit/location/location_state.dart
+++ b/lib/data/cubit/location/location_state.dart
@@ -10,10 +10,27 @@ class LocationLoaded extends LocationState {
   LocationLoaded({required this.latitude, required this.longitude});
 }
 
-/// The user explicitly denied (or revoked) the location permission.
-/// → Show the "Activar" banner.
+/// El usuario denegó (o aún no concedió) el permiso de ubicación. Puede
+/// volver a mostrarse el modal nativo del sistema.
+///
+/// Sub-tipos para distinguir la acción adecuada:
+///   - [LocationDenied] base: aún no se pidió o se denegó una vez (iOS sigue
+///     permitiendo mostrar el modal nativo otra vez).
+///   - [LocationPermanentlyDenied]: el usuario rechazó "Don't allow" y iOS
+///     no volverá a mostrar el modal — hay que llevarlo a Ajustes.
+///   - [LocationServiceDisabled]: el servicio de ubicación del sistema está
+///     apagado a nivel del dispositivo (Settings → Privacy → Location → Off).
+///     `requestPermission` no puede arreglar esto: hay que enviar a Ajustes.
+///
+/// Importante: jerarquía por herencia para retrocompatibilidad. Los checks
+/// existentes `state is LocationDenied` siguen funcionando para los tres
+/// estados (todos son `LocationDenied`).
 class LocationDenied extends LocationState {}
 
-/// Permission is granted but we could not obtain a GPS fix.
-/// → Hide the section silently (no misleading banner).
+class LocationPermanentlyDenied extends LocationDenied {}
+
+class LocationServiceDisabled extends LocationDenied {}
+
+/// Permiso concedido pero no se pudo obtener fix de GPS.
+/// → Ocultar la sección silenciosamente (sin banner engañoso).
 class LocationUnavailable extends LocationState {}

--- a/lib/ui/components/location_prompt_banner.dart
+++ b/lib/ui/components/location_prompt_banner.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/config/brand_colors.dart';
+import 'package:guachinches/data/cubit/location/location_cubit.dart';
+import 'package:guachinches/data/cubit/location/location_state.dart';
+import 'package:guachinches/utils/location_prompt_action.dart';
+
+/// Banner global que pide activar la ubicación.
+///
+/// Comportamiento adaptativo según el sub-tipo de `LocationDenied`:
+///  - [LocationDenied] base: tap → `requestLocation()` (intenta modal nativo).
+///  - [LocationPermanentlyDenied]: tap → push [LocationDeniedScreen] con
+///    instrucciones para Ajustes.
+///  - [LocationServiceDisabled]: tap → push [LocationDeniedScreen] con
+///    instrucciones para activar Servicios de Localización.
+///
+/// Se oculta automáticamente en `LocationLoaded`, `LocationLoading`,
+/// `LocationInitial` y `LocationUnavailable`.
+class LocationPromptBanner extends StatelessWidget {
+  /// Si `true` el banner usa un layout más compacto (1 línea) — pensado para
+  /// el home. Si `false` (default) muestra eyebrow + título + sub-copy.
+  final bool compact;
+
+  const LocationPromptBanner({super.key, this.compact = false});
+
+  // El comportamiento lo gestiona el helper compartido para que el banner
+  // y la pantalla `CercaAhoraScreen` reaccionen igual.
+  Future<void> _onTap(BuildContext context) =>
+      handleLocationPromptTap(context);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<LocationCubit, LocationState>(
+      builder: (context, state) {
+        if (state is! LocationDenied) {
+          // LocationDenied es la base de las 3 variantes → cubre todo.
+          return const SizedBox.shrink();
+        }
+
+        final isPermanent = state is LocationPermanentlyDenied;
+        final isServiceOff = state is LocationServiceDisabled;
+        final needsSettings = isPermanent || isServiceOff;
+
+        final eyebrow = isServiceOff
+            ? 'UBICACIÓN APAGADA'
+            : (isPermanent ? 'PERMISO BLOQUEADO' : 'ACTIVAR UBICACIÓN');
+        final title = isServiceOff
+            ? 'Activa Servicios de Localización'
+            : 'Ver lo que está cerca de ti';
+        final cta = needsSettings ? 'Ajustes' : 'Activar';
+
+        return Semantics(
+          identifier: 'home-location-prompt',
+          button: true,
+          child: GestureDetector(
+            onTap: () => _onTap(context),
+            child: Container(
+              margin: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+              decoration: BoxDecoration(
+                color: context.brand.surface,
+                borderRadius: BorderRadius.circular(14),
+                border: Border.all(color: context.brand.border, width: 1),
+              ),
+              clipBehavior: Clip.hardEdge,
+              child: IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Container(width: 4, color: AppColors.atlantico),
+                    Expanded(
+                      child: Padding(
+                        padding: EdgeInsets.fromLTRB(
+                          12,
+                          compact ? 10 : 12,
+                          12,
+                          compact ? 10 : 12,
+                        ),
+                        child: Row(
+                          children: [
+                            Container(
+                              width: 36,
+                              height: 36,
+                              decoration: BoxDecoration(
+                                color: AppColors.atlantico.withOpacity(0.10),
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              child: const Icon(
+                                Icons.location_on_rounded,
+                                color: AppColors.atlantico,
+                                size: 20,
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  if (!compact)
+                                    Text(
+                                      eyebrow,
+                                      style: AppTextStyles.eyebrow(
+                                        size: 10,
+                                        color: AppColors.atlantico,
+                                      ),
+                                    ),
+                                  if (!compact) const SizedBox(height: 3),
+                                  Text(
+                                    title,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: AppTextStyles.ui(
+                                      size: compact ? 13 : 14,
+                                      weight: FontWeight.w600,
+                                      color: context.brand.textPrimary,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 12, vertical: 8),
+                              decoration: BoxDecoration(
+                                color: AppColors.atlantico,
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              child: Text(
+                                cta,
+                                style: AppTextStyles.ui(
+                                  size: 12,
+                                  weight: FontWeight.w600,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/components/open_now_callout.dart
+++ b/lib/ui/components/open_now_callout.dart
@@ -1,0 +1,244 @@
+import 'package:flutter/material.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/config/brand_colors.dart';
+
+/// Callout "Abiertos AHORA" — entry point a [CercaAhoraScreen].
+///
+/// Diseño:
+/// - Fondo `surface` del tema (theme-aware light/dark), no amarillo brillante:
+///   evita el choque visual con la paleta atlántico y arregla el contraste
+///   bajo del card antiguo (texto blanco sobre amarillo crema = ~1.8:1).
+/// - Banda lateral izquierda gruesa (4px) en `laurisilva` (verde "abierto")
+///   como indicador semántico — el ojo lee "estado en vivo" sin necesidad de
+///   leer copy.
+/// - LIVE dot pulsante (animación opacity 0.4 → 1.0 en loop) refuerza el
+///   sentido de "ahora mismo".
+/// - Jerarquía: eyebrow pequeño ("ABIERTOS AHORA · TENERIFE") sobre número
+///   grande ("23 sitios cerca") en lugar de texto plano de 15pt.
+/// - Si [count] == 0 cambia a tono `sol` (amarillo cálido) con copy "Sin
+///   abiertos cerca · Abren pronto" — sigue siendo accionable.
+class OpenNowCallout extends StatefulWidget {
+  /// Número de restaurantes abiertos AHORA en el contexto actual.
+  final int count;
+
+  /// Nombre de isla / zona para el contexto ("Tenerife", "La Gomera"…).
+  final String contextLabel;
+
+  /// Acción al tap. Si null, el callout pierde la sombra y el chevron.
+  final VoidCallback? onTap;
+
+  const OpenNowCallout({
+    super.key,
+    required this.count,
+    required this.contextLabel,
+    this.onTap,
+  });
+
+  @override
+  State<OpenNowCallout> createState() => _OpenNowCalloutState();
+}
+
+class _OpenNowCalloutState extends State<OpenNowCallout>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulse;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulse = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1400),
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _pulse.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasOpen = widget.count > 0;
+    // Color semántico: verde si hay abiertos, sol (cálido) si toca esperar.
+    final accent = hasOpen ? AppColors.laurisilva : AppColors.sol;
+    final eyebrowText = hasOpen
+        ? 'ABIERTOS AHORA · ${widget.contextLabel.toUpperCase()}'
+        : 'ABRE PRONTO · ${widget.contextLabel.toUpperCase()}';
+    final headlineText = hasOpen
+        ? _headlineForCount(widget.count)
+        : 'Sin abiertos cerca';
+    final supportText =
+        hasOpen ? 'Toca para ver el listado' : 'Abren a lo largo del día';
+
+    return Semantics(
+      identifier: 'home-cerca-ahora-cta',
+      button: widget.onTap != null,
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: Container(
+          margin: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          decoration: BoxDecoration(
+            color: context.brand.surface,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: context.brand.border, width: 1),
+            boxShadow: widget.onTap == null
+                ? null
+                : [
+                    BoxShadow(
+                      color: accent.withOpacity(0.08),
+                      blurRadius: 18,
+                      offset: const Offset(0, 6),
+                    ),
+                  ],
+          ),
+          clipBehavior: Clip.hardEdge,
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Banda lateral: indicador semántico de "estado en vivo".
+                Container(
+                  width: 4,
+                  decoration: BoxDecoration(
+                    color: accent,
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(16),
+                      bottomLeft: Radius.circular(16),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(14, 14, 12, 14),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Row(
+                                children: [
+                                  if (hasOpen) ...[
+                                    _LiveDot(controller: _pulse, color: accent),
+                                    const SizedBox(width: 6),
+                                  ],
+                                  Flexible(
+                                    child: Text(
+                                      eyebrowText,
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: AppTextStyles.eyebrow(
+                                        size: 10,
+                                        color: accent,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 6),
+                              Text(
+                                headlineText,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: AppTextStyles.displayHero(
+                                  size: 22,
+                                  color: context.brand.textPrimary,
+                                ),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                supportText,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: AppTextStyles.ui(
+                                  size: 12,
+                                  color: context.brand.textSecondary,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        if (widget.onTap != null)
+                          Container(
+                            width: 36,
+                            height: 36,
+                            decoration: BoxDecoration(
+                              color: accent.withOpacity(0.12),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Icon(
+                              Icons.arrow_forward_rounded,
+                              color: accent,
+                              size: 18,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Copy del headline en función del count. Singular vs plural y un fallback
+  /// "Muchos sitios cerca" para > 99 que evita números desproporcionados en el
+  /// hero (mantiene la composición tipográfica).
+  String _headlineForCount(int n) {
+    if (n == 1) return '1 sitio abierto cerca';
+    if (n > 99) return 'Muchos abiertos cerca';
+    return '$n sitios abiertos cerca';
+  }
+}
+
+/// Punto verde pulsante. Animación rápida (opacity + scale) para comunicar
+/// "live" sin distraer. Stateless por fuera — el [controller] lo gestiona el
+/// padre, así evitamos múltiples controllers si el callout se reconstruye.
+class _LiveDot extends StatelessWidget {
+  final AnimationController controller;
+  final Color color;
+
+  const _LiveDot({required this.controller, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (_, __) {
+        final t = controller.value; // 0 → 1 → 0
+        final opacity = 0.45 + 0.55 * t;
+        final scale = 0.85 + 0.15 * t;
+        return SizedBox(
+          width: 10,
+          height: 10,
+          child: Center(
+            child: Transform.scale(
+              scale: scale,
+              child: Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: color.withOpacity(opacity),
+                  shape: BoxShape.circle,
+                  boxShadow: [
+                    BoxShadow(
+                      color: color.withOpacity(0.35 * t),
+                      blurRadius: 6,
+                      spreadRadius: 1,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/pages/cerca_abiertos/cerca_ahora_screen.dart
+++ b/lib/ui/pages/cerca_abiertos/cerca_ahora_screen.dart
@@ -14,6 +14,7 @@ import 'package:guachinches/data/cubit/restaurants/basic/restaurant_state.dart';
 import 'package:guachinches/data/local/http_cache_store.dart';
 import 'package:guachinches/data/model/restaurant.dart';
 import 'package:guachinches/ui/components/cards/nearby_restaurant_card.dart';
+import 'package:guachinches/utils/location_prompt_action.dart';
 
 class CercaAhoraScreen extends StatefulWidget {
   final int initialLimit;
@@ -41,13 +42,20 @@ class _CercaAhoraScreenState extends State<CercaAhoraScreen> {
     _maxRadiusKm = widget.maxRadiusKm;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      final locState = context.read<LocationCubit>().state;
+      final cubit = context.read<LocationCubit>();
+      final locState = cubit.state;
       _logEvent('cerca_ahora_opened', {
         'has_location': locState is LocationLoaded ? 1 : 0,
       });
       if (locState is LocationLoaded && !_initialized) {
         _initialized = true;
         _fetchRestaurants(locState);
+      } else if (locState is LocationInitial) {
+        // Si el cubit aún no ha arrancado (caso típico al entrar desde el
+        // callout antes de que termine el bootstrap del home), pedimos la
+        // ubicación aquí. Si el user tiene permisos esto resuelve a
+        // LocationLoaded sin mostrar el empty state.
+        unawaited(cubit.requestLocation());
       }
     });
   }
@@ -139,10 +147,18 @@ class _CercaAhoraScreenState extends State<CercaAhoraScreen> {
           ),
           body: BlocBuilder<LocationCubit, LocationState>(
             builder: (context, locationState) {
-              if (locationState is! LocationLoaded) {
-                return _buildLocationRequired(context, locationState);
+              // Loading / Initial: spinner mientras el cubit resuelve.
+              // Evita mostrar "Necesitamos ubicación" prematuramente cuando
+              // el usuario SÍ tiene permisos pero el cubit aún no terminó.
+              if (locationState is LocationInitial ||
+                  locationState is LocationLoading) {
+                return const Center(child: CircularProgressIndicator());
               }
-              return _buildContent(context, locationState);
+              if (locationState is LocationLoaded) {
+                return _buildContent(context, locationState);
+              }
+              // LocationDenied (y sub-tipos) + LocationUnavailable.
+              return _buildLocationRequired(context, locationState);
             },
           ),
         ),
@@ -195,13 +211,7 @@ class _CercaAhoraScreenState extends State<CercaAhoraScreen> {
                       borderRadius: BorderRadius.circular(12),
                     ),
                   ),
-                  onPressed: () {
-                    if (state is LocationDenied) {
-                      Geolocator.openAppSettings();
-                    } else {
-                      context.read<LocationCubit>().requestLocation();
-                    }
-                  },
+                  onPressed: () => handleLocationPromptTap(context),
                   child: const Text(
                     'Activar ubicación',
                     style: TextStyle(fontFamily: 'SF Pro Display'),

--- a/lib/ui/pages/location_denied/location_denied_screen.dart
+++ b/lib/ui/pages/location_denied/location_denied_screen.dart
@@ -1,0 +1,292 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/app_text_styles.dart';
+import 'package:guachinches/config/brand_colors.dart';
+import 'package:guachinches/data/cubit/location/location_cubit.dart';
+import 'package:guachinches/data/cubit/location/location_state.dart';
+
+/// Pantalla de instrucciones para reactivar la ubicación cuando el modal
+/// nativo ya no se puede mostrar (`LocationPermanentlyDenied`) o el servicio
+/// está apagado a nivel del dispositivo (`LocationServiceDisabled`).
+///
+/// Diseño:
+/// - Header hero con icono grande + título claro.
+/// - Lista de pasos numerados en cards con iconos del sistema.
+/// - CTA primario "Abrir Ajustes" que lanza `Geolocator.openAppSettings()`
+///   (o `openLocationSettings()` cuando es servicio del sistema).
+/// - CTA secundario "Más tarde" que vuelve.
+/// - Al volver del background tras cambiar Ajustes, el `checkLocationSilently`
+///   del cubit detecta el cambio y dispara `LocationLoaded` automáticamente.
+class LocationDeniedScreen extends StatelessWidget {
+  const LocationDeniedScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<LocationCubit, LocationState>(
+      builder: (context, state) {
+        // Si por lo que sea volvemos aquí con permiso ya concedido, cerrar.
+        if (state is LocationLoaded) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (Navigator.of(context).canPop()) Navigator.of(context).pop();
+          });
+        }
+        final serviceDisabled = state is LocationServiceDisabled;
+        return Scaffold(
+          backgroundColor: context.brand.base,
+          body: SafeArea(
+            child: Semantics(
+              identifier: 'location-denied-screen',
+              child: Column(
+                children: [
+                  _Header(serviceDisabled: serviceDisabled),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
+                      child: _StepsList(serviceDisabled: serviceDisabled),
+                    ),
+                  ),
+                  _Actions(serviceDisabled: serviceDisabled),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  final bool serviceDisabled;
+  const _Header({required this.serviceDisabled});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8, 4, 8, 0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: IconButton(
+              icon: Icon(Icons.close_rounded, color: context.brand.textPrimary),
+              onPressed: () => Navigator.of(context).maybePop(),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 8, 12, 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 64,
+                  height: 64,
+                  decoration: BoxDecoration(
+                    color: AppColors.atlantico.withOpacity(0.12),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: const Icon(
+                    Icons.location_on_rounded,
+                    color: AppColors.atlantico,
+                    size: 32,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  serviceDisabled
+                      ? 'UBICACIÓN APAGADA'
+                      : 'NECESITAMOS TU UBICACIÓN',
+                  style: AppTextStyles.eyebrow(
+                    size: 11,
+                    color: AppColors.atlantico,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  serviceDisabled
+                      ? 'Activa los Servicios de Ubicación'
+                      : 'Permite el acceso a tu ubicación',
+                  style: AppTextStyles.displayHero(
+                    size: 28,
+                    color: context.brand.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  serviceDisabled
+                      ? 'Tu iPhone tiene los Servicios de Ubicación apagados. Actívalos en Ajustes para ver los restaurantes cerca de ti.'
+                      : 'Para mostrarte los abiertos cerca de ti y calcular distancias, necesitamos acceso a tu ubicación. Sigue estos pasos en Ajustes:',
+                  style: AppTextStyles.ui(
+                    size: 14,
+                    color: context.brand.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StepsList extends StatelessWidget {
+  final bool serviceDisabled;
+  const _StepsList({required this.serviceDisabled});
+
+  @override
+  Widget build(BuildContext context) {
+    final steps = serviceDisabled
+        ? const [
+            _Step(n: 1, label: 'Abre Ajustes', icon: Icons.settings_rounded),
+            _Step(n: 2, label: 'Privacidad y seguridad', icon: Icons.shield_outlined),
+            _Step(n: 3, label: 'Localización', icon: Icons.location_on_outlined),
+            _Step(
+              n: 4,
+              label: 'Activa "Servicios de Localización"',
+              icon: Icons.toggle_on_rounded,
+            ),
+          ]
+        : const [
+            _Step(n: 1, label: 'Abre Ajustes de la app', icon: Icons.settings_rounded),
+            _Step(n: 2, label: 'Toca "Ubicación"', icon: Icons.location_on_outlined),
+            _Step(
+              n: 3,
+              label: 'Selecciona "Al usar la app"',
+              icon: Icons.check_circle_outline,
+            ),
+          ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final s in steps) ...[
+          s,
+          const SizedBox(height: 10),
+        ],
+      ],
+    );
+  }
+}
+
+class _Step extends StatelessWidget {
+  final int n;
+  final String label;
+  final IconData icon;
+
+  const _Step({required this.n, required this.label, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: context.brand.surface,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: context.brand.border, width: 1),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 28,
+            height: 28,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: AppColors.atlantico.withOpacity(0.10),
+              shape: BoxShape.circle,
+            ),
+            child: Text(
+              '$n',
+              style: AppTextStyles.ui(
+                size: 13,
+                weight: FontWeight.w700,
+                color: AppColors.atlantico,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              label,
+              style: AppTextStyles.ui(
+                size: 14,
+                weight: FontWeight.w500,
+                color: context.brand.textPrimary,
+              ),
+            ),
+          ),
+          Icon(icon, color: context.brand.textMuted, size: 20),
+        ],
+      ),
+    );
+  }
+}
+
+class _Actions extends StatelessWidget {
+  final bool serviceDisabled;
+  const _Actions({required this.serviceDisabled});
+
+  Future<void> _open() async {
+    // En iOS no hay diferencia funcional — ambos llevan a Ajustes. En
+    // Android sí: `openLocationSettings` abre directo el toggle del sistema.
+    if (Platform.isAndroid && serviceDisabled) {
+      await Geolocator.openLocationSettings();
+    } else {
+      await Geolocator.openAppSettings();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+          20, 8, 20, MediaQuery.of(context).viewPadding.bottom + 12),
+      child: Column(
+        children: [
+          SizedBox(
+            width: double.infinity,
+            child: Semantics(
+              identifier: 'location-denied-open-settings',
+              button: true,
+              child: ElevatedButton(
+                onPressed: _open,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.atlantico,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  textStyle: AppTextStyles.ui(
+                    size: 15,
+                    weight: FontWeight.w600,
+                  ),
+                ),
+                child: const Text('Abrir Ajustes'),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: () => Navigator.of(context).maybePop(),
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+            ),
+            child: Text(
+              'Más tarde',
+              style: AppTextStyles.ui(
+                size: 14,
+                weight: FontWeight.w500,
+                color: context.brand.textSecondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/new_home/new_home_body.dart
+++ b/lib/ui/pages/new_home/new_home_body.dart
@@ -21,12 +21,15 @@ import 'package:guachinches/ui/pages/new_home/widgets/canarian_specialties_secti
 import 'package:guachinches/ui/pages/curated_list_detail/curated_list_detail_screen.dart';
 import 'package:guachinches/ui/pages/discover/discover_screen.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/card_curated_list.dart';
-import 'package:guachinches/ui/pages/new_home/widgets/card_horizontal.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/card_nearby_minimap.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/card_visit.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/hour_aware_banner.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/parallax_hero.dart';
+import 'package:guachinches/ui/components/location_prompt_banner.dart';
+import 'package:guachinches/ui/components/open_now_callout.dart';
 import 'package:guachinches/ui/pages/cerca_abiertos/cerca_ahora_screen.dart';
+import 'package:guachinches/ui/pages/new_home/widgets/card_horizontal.dart';
+import 'package:guachinches/ui/pages/new_home/widgets/contextual_section_card.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/search_field_dynamic.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/section_header.dart';
 import 'package:guachinches/ui/pages/new_home/widgets/skeletons.dart';
@@ -160,72 +163,24 @@ class _NewHomeBodyState extends State<NewHomeBody> {
               ),
             ),
 
+            // ── LOCATION PROMPT (si no hay permiso) ──────────────────────
+            // Banner adaptativo: si LocationDenied → tap dispara modal nativo;
+            // si LocationPermanentlyDenied/ServiceDisabled → push guía a
+            // Ajustes. Auto-oculto cuando hay permiso (LocationLoaded).
+            const SliverToBoxAdapter(child: LocationPromptBanner()),
+
             // ── ABIERTOS CERCA AHORA ─────────────────────────────────────
+            // Callout rediseñado con LIVE dot pulsante, número real de
+            // abiertos y banda lateral verde "laurisilva". Ver
+            // [OpenNowCallout] para el rationale del diseño.
             SliverToBoxAdapter(
-              child: Semantics(
-                identifier: 'home-cerca-ahora-cta',
-                child: GestureDetector(
-                  onTap: () => Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => const CercaAhoraScreen(),
-                    ),
-                  ),
-                  child: Container(
-                    margin: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: AppColors.sol.withOpacity(0.12),
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(color: AppColors.sol, width: 1.5),
-                    ),
-                    child: Row(
-                      children: [
-                        Container(
-                          padding: const EdgeInsets.all(8),
-                          decoration: BoxDecoration(
-                            color: AppColors.sol,
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                          child: const Icon(
-                            Icons.bolt,
-                            color: Colors.black87,
-                            size: 22,
-                          ),
-                        ),
-                        const SizedBox(width: 14),
-                        const Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                'Abiertos cerca AHORA',
-                                style: TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  color: Colors.white,
-                                  fontSize: 15,
-                                  fontFamily: 'SF Pro Display',
-                                ),
-                              ),
-                              SizedBox(height: 2),
-                              Text(
-                                'Toca para ver disponibles',
-                                style: TextStyle(
-                                  color: Colors.white70,
-                                  fontSize: 12,
-                                  fontFamily: 'SF Pro Display',
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        const Icon(
-                          Icons.chevron_right,
-                          color: AppColors.sol,
-                          size: 24,
-                        ),
-                      ],
-                    ),
+              child: OpenNowCallout(
+                count: openNow.length,
+                contextLabel: zoneLabel,
+                onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const CercaAhoraScreen(),
                   ),
                 ),
               ),
@@ -235,40 +190,68 @@ class _NewHomeBodyState extends State<NewHomeBody> {
             // Sólo mostramos esta sección si hay restaurantes con horario
             // confirmado abiertos ahora; si no, ocultamos banner + row para
             // no anunciar "abiertos ahora" sobre listas dudosas.
+            //
+            // Banner + carrusel van envueltos en [ContextualSectionCard]
+            // (fondo crema + banda lateral) para que se lean como una unidad
+            // visual, en lugar de dos elementos sueltos. El scroll interno
+            // sigue siendo el `CardHorizontal` clásico (no se toca).
             if (widget.bootstrapLoading) ...[
               SliverToBoxAdapter(
-                child: HourAwareBanner(
-                  hour: widget.hour,
-                  zoneLabel: zoneLabel,
-                  actionLabel: 'VER TODO',
-                  onAction: () {},
+                child: ContextualSectionCard(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      HourAwareBanner(
+                        hour: widget.hour,
+                        zoneLabel: zoneLabel,
+                        actionLabel: 'VER TODO',
+                        onAction: () {},
+                      ),
+                      const CardRowSkeleton(),
+                    ],
+                  ),
                 ),
               ),
-              const SliverToBoxAdapter(child: CardRowSkeleton()),
             ] else if (showTodaySection) ...[
               SliverToBoxAdapter(
-                child: HourAwareBanner(
-                  hour: widget.hour,
-                  zoneLabel: zoneLabel,
-                  actionLabel: 'VER TODO',
-                  onAction: () {},
-                  count: contextualCount,
+                child: ContextualSectionCard(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      HourAwareBanner(
+                        hour: widget.hour,
+                        zoneLabel: zoneLabel,
+                        actionLabel: 'VER TODO',
+                        onAction: () {},
+                        count: contextualCount,
+                      ),
+                      _buildHorizontalRow(todayPool),
+                    ],
+                  ),
                 ),
               ),
-              SliverToBoxAdapter(child: _buildHorizontalRow(todayPool)),
             ] else if (showOpeningSoonSection) ...[
               SliverToBoxAdapter(
-                child: HourAwareBanner(
-                  hour: widget.hour,
-                  zoneLabel: zoneLabel,
-                  // Sin "VER TODO" en este modo: la lista ya es pequeña y
-                  // todo el contenido relevante está en el carrusel.
-                  count: openingLater.length,
-                  mode: HourBannerMode.openingSoon,
+                child: ContextualSectionCard(
+                  // Banda lateral en `sol` (amarillo cálido) para
+                  // distinguir visualmente "abren pronto" del modo normal.
+                  accent: AppColors.sol,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      HourAwareBanner(
+                        hour: widget.hour,
+                        zoneLabel: zoneLabel,
+                        // Sin "VER TODO" en este modo: la lista ya es
+                        // pequeña y todo el contenido relevante está en
+                        // el carrusel.
+                        count: openingLater.length,
+                        mode: HourBannerMode.openingSoon,
+                      ),
+                      _buildHorizontalRowOpeningSoon(openingSoonPool, now),
+                    ],
+                  ),
                 ),
-              ),
-              SliverToBoxAdapter(
-                child: _buildHorizontalRowOpeningSoon(openingSoonPool, now),
               ),
             ],
 

--- a/lib/ui/pages/new_home/widgets/contextual_section_card.dart
+++ b/lib/ui/pages/new_home/widgets/contextual_section_card.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:guachinches/config/app_colors.dart';
+import 'package:guachinches/config/brand_colors.dart';
+
+/// Envoltorio visual de la sección "HOY EN ..." (banner contextual + carrusel
+/// de restaurantes). Fondo crema, banda lateral cálida y borde redondeado —
+/// agrupa banner y cards en un mismo bloque para que se lean como una unidad
+/// en vez de dos elementos sueltos.
+///
+/// El `child` típicamente es:
+/// ```
+/// Column(children: [HourAwareBanner(...), _buildHorizontalRow(...)])
+/// ```
+/// El padding interno es 0 horizontal para que el scroll de cards corte por
+/// el borde derecho (efecto "asoma siguiente") — el scroll trae su propio
+/// padding inicial. Vertical: 6 top + 14 bottom para no apretar el banner.
+class ContextualSectionCard extends StatelessWidget {
+  final Widget child;
+
+  /// Color de la banda lateral izquierda. Por defecto `tierra` (marrón
+  /// canario cálido) — coincide con la sensación del banner de hora. Si
+  /// quieres distinguir el modo "abren pronto" puedes pasar `sol`.
+  final Color accent;
+
+  const ContextualSectionCard({
+    super.key,
+    required this.child,
+    this.accent = AppColors.tierra,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      // Más margen vertical externo (16↓) para separarse del siguiente
+      // bloque del scroll. 12↑ mantiene el aire con el callout anterior.
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 16),
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.cremaSoft,
+          borderRadius: BorderRadius.circular(22),
+          border: Border.all(color: context.brand.border, width: 1),
+          boxShadow: [
+            // Sombra más amplia y suave → la card se siente "asentada"
+            // sobre el fondo en vez de pegada como un parche.
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 22,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        clipBehavior: Clip.hardEdge,
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Banda lateral cálida — pista visual de "bloque contextual".
+              // 3px se integra mejor (4px llamaba demasiado la atención).
+              Container(width: 3, color: accent),
+              Expanded(
+                child: Padding(
+                  // Interior: respiro arriba (10) y abajo (20) para que el
+                  // carrusel no toque el borde de la card. 20↓ es el que
+                  // hace que el nombre/rating de la última fila respire.
+                  padding: const EdgeInsets.only(top: 10, bottom: 20),
+                  child: child,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/splash_screen/splash_screen.dart
+++ b/lib/ui/pages/splash_screen/splash_screen.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:guachinches/core/logging/app_logger.dart';
 import 'package:guachinches/data/HttpRemoteRepository.dart';
 import 'package:guachinches/data/RemoteRepository.dart';
 import 'package:guachinches/data/cubit/onboarding/onboarding_cubit.dart';
@@ -24,6 +26,8 @@ class _SplashScreenState extends State<SplashScreen>
     implements SplashScreenView {
   late RemoteRepository remoteRepository;
   late SplashScreenPresenter presenter;
+  Timer? _watchdog;
+  bool _navigated = false;
 
 
   @override
@@ -35,7 +39,23 @@ class _SplashScreenState extends State<SplashScreen>
         this, remoteRepository, userCubit, onboardingCubit);
     presenter.getUserInfo();
 
+    // Watchdog: si en 12s no se ha navegado, forzamos el flujo principal
+    // para evitar que el splash quede colgado por una respuesta del
+    // backend que no llega. El presenter ya tiene timeouts en getVersion,
+    // pero esto cubre cualquier futuro await sin timeout en la cadena.
+    _watchdog = Timer(const Duration(seconds: 12), () {
+      if (_navigated || !mounted) return;
+      AppLogger.warn('splash', 'watchdog_fired forcing_main_function');
+      presenter.mainFunction();
+    });
+
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _watchdog?.cancel();
+    super.dispose();
   }
 
   @override
@@ -59,6 +79,9 @@ class _SplashScreenState extends State<SplashScreen>
 
   @override
   goToMenu(List<Widget> screens) {
+    if (_navigated || !mounted) return;
+    _navigated = true;
+    _watchdog?.cancel();
     GlobalMethods().pushAndReplacement(
       context,
       NewHomeTabScaffold(screens: screens),
@@ -67,15 +90,24 @@ class _SplashScreenState extends State<SplashScreen>
 
   @override
   goToUpdateScreen() {
+    if (_navigated || !mounted) return;
+    _navigated = true;
+    _watchdog?.cancel();
     GlobalMethods().pushAndReplacement(context, UpdateAppScreen());
   }
   @override
   goToOnBoarding() {
+    if (_navigated || !mounted) return;
+    _navigated = true;
+    _watchdog?.cancel();
     GlobalMethods().pushAndReplacement(context, const OnboardingFlow());
   }
 
   @override
   goToSurveyOnboarding(List<Widget> screens) {
+    if (_navigated || !mounted) return;
+    _navigated = true;
+    _watchdog?.cancel();
     GlobalMethods().pushAndReplacement(context, SurveyOnboarding(screens: screens));
   }
 }

--- a/lib/ui/pages/splash_screen/splash_screen_presenter.dart
+++ b/lib/ui/pages/splash_screen/splash_screen_presenter.dart
@@ -73,20 +73,31 @@ class SplashScreenPresenter {
 
 
   getUserInfo() async {
-    Version version = await _remoteRepository.getVersion();
-
+    // Si `getVersion` falla (timeout, offline, backend caído), seguimos
+    // adelante con `versionBD = "1.0.0"`. Esto NO debe bloquear el arranque
+    // de la app: en el peor caso saltamos la comprobación de versión y el
+    // usuario ve el home igualmente. El check de "actualiza la app" se hará
+    // la próxima vez que el backend responda.
     String versionBD = "1.0.0";
-
-
-
-
-
-    if (Platform.isIOS == true) {
-      versionBD = version.iosVersion;
-    } else {
-      versionBD = version.androidVersion;
+    try {
+      final Version version = await _remoteRepository.getVersion();
+      if (Platform.isIOS == true) {
+        versionBD = version.iosVersion;
+      } else {
+        versionBD = version.androidVersion;
+      }
+    } catch (_) {
+      // Continuamos con versionBD = "1.0.0" → check devuelve false → no
+      // forzamos UpdateScreen y el flujo sigue.
     }
-    bool check = await checkVersion(versionBD);
+
+    bool check = false;
+    try {
+      check = await checkVersion(versionBD);
+    } catch (_) {
+      check = false;
+    }
+
     if (check) {
       _view.goToUpdateScreen();
     } else {

--- a/lib/utils/location_prompt_action.dart
+++ b/lib/utils/location_prompt_action.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:guachinches/data/cubit/location/location_cubit.dart';
+import 'package:guachinches/data/cubit/location/location_state.dart';
+import 'package:guachinches/ui/pages/location_denied/location_denied_screen.dart';
+
+/// Acción correcta al tap en cualquier CTA "Activar ubicación" según el
+/// sub-tipo de [LocationDenied].
+///
+///  - `LocationDenied` base → `requestLocation()` (modal nativo iOS).
+///  - `LocationPermanentlyDenied` → push [LocationDeniedScreen].
+///  - `LocationServiceDisabled` → push [LocationDeniedScreen].
+///  - Cualquier otro estado → llamar `requestLocation()` defensivamente
+///    (cubre `LocationInitial` por si una pantalla profunda usa el helper
+///    antes de que el cubit haya arrancado).
+///
+/// Comparte la lógica entre [LocationPromptBanner] y [CercaAhoraScreen] para
+/// que el comportamiento sea idéntico en todas partes.
+Future<void> handleLocationPromptTap(BuildContext context) async {
+  final cubit = context.read<LocationCubit>();
+  final state = cubit.state;
+  if (state is LocationPermanentlyDenied ||
+      state is LocationServiceDisabled) {
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const LocationDeniedScreen()),
+    );
+    if (context.mounted) {
+      await cubit.checkLocationSilently();
+    }
+    return;
+  }
+  await cubit.requestLocation();
+}

--- a/test/ui/components/location_prompt_banner_test.dart
+++ b/test/ui/components/location_prompt_banner_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guachinches/config/app_theme.dart';
+import 'package:guachinches/data/cubit/location/location_cubit.dart';
+import 'package:guachinches/data/cubit/location/location_state.dart';
+import 'package:guachinches/ui/components/location_prompt_banner.dart';
+
+Finder _bySemId(String id) => find.byWidgetPredicate(
+      (w) => w is Semantics && w.properties.identifier == id,
+    );
+
+/// Fake cubit con un estado fijo. Evita depender de la API real de geolocator
+/// en widget tests, que no responde correctamente al stub de método nativo.
+class _FakeLocationCubit extends Cubit<LocationState> implements LocationCubit {
+  _FakeLocationCubit(LocationState initial) : super(initial);
+
+  int requestCalls = 0;
+  int silentCalls = 0;
+
+  @override
+  Future<void> requestLocation() async {
+    requestCalls++;
+  }
+
+  @override
+  Future<void> checkLocationSilently() async {
+    silentCalls++;
+  }
+}
+
+Widget _wrap(Widget child, LocationState state, _FakeLocationCubit cubit) {
+  return MaterialApp(
+    theme: appLightTheme,
+    darkTheme: appDarkTheme,
+    home: BlocProvider<LocationCubit>.value(
+      value: cubit,
+      child: Scaffold(body: SizedBox(width: 400, child: child)),
+    ),
+  );
+}
+
+void main() {
+  group('LocationPromptBanner', () {
+    testWidgets('(a) LocationLoaded → no renderiza nada', (tester) async {
+      final cubit = _FakeLocationCubit(
+        LocationLoaded(latitude: 28.0, longitude: -16.5),
+      );
+      await tester.pumpWidget(_wrap(
+        const LocationPromptBanner(),
+        cubit.state,
+        cubit,
+      ));
+      await tester.pump();
+      expect(_bySemId('home-location-prompt'), findsNothing);
+    });
+
+    testWidgets('(b) LocationInitial → no renderiza nada', (tester) async {
+      final cubit = _FakeLocationCubit(LocationInitial());
+      await tester.pumpWidget(_wrap(
+        const LocationPromptBanner(),
+        cubit.state,
+        cubit,
+      ));
+      await tester.pump();
+      expect(_bySemId('home-location-prompt'), findsNothing);
+    });
+
+    testWidgets('(c) LocationDenied base → renderiza banner "Activar"',
+        (tester) async {
+      final cubit = _FakeLocationCubit(LocationDenied());
+      await tester.pumpWidget(_wrap(
+        const LocationPromptBanner(),
+        cubit.state,
+        cubit,
+      ));
+      await tester.pump();
+      expect(_bySemId('home-location-prompt'), findsOneWidget);
+      expect(find.text('ACTIVAR UBICACIÓN'), findsOneWidget);
+      expect(find.text('Activar'), findsOneWidget);
+    });
+
+    testWidgets(
+        '(d) LocationDenied base → tap llama requestLocation (modal nativo)',
+        (tester) async {
+      final cubit = _FakeLocationCubit(LocationDenied());
+      await tester.pumpWidget(_wrap(
+        const LocationPromptBanner(),
+        cubit.state,
+        cubit,
+      ));
+      await tester.pump();
+      await tester.tap(_bySemId('home-location-prompt'));
+      await tester.pump();
+      expect(cubit.requestCalls, 1);
+    });
+
+    testWidgets(
+        '(e) LocationPermanentlyDenied → CTA dice "Ajustes" (no "Activar")',
+        (tester) async {
+      final cubit = _FakeLocationCubit(LocationPermanentlyDenied());
+      await tester.pumpWidget(_wrap(
+        const LocationPromptBanner(),
+        cubit.state,
+        cubit,
+      ));
+      await tester.pump();
+      expect(find.text('Ajustes'), findsOneWidget);
+      expect(find.text('Activar'), findsNothing);
+      expect(find.text('PERMISO BLOQUEADO'), findsOneWidget);
+    });
+
+    testWidgets(
+        '(f) LocationServiceDisabled → copy explícita "Servicios de Localización"',
+        (tester) async {
+      final cubit = _FakeLocationCubit(LocationServiceDisabled());
+      await tester.pumpWidget(_wrap(
+        const LocationPromptBanner(),
+        cubit.state,
+        cubit,
+      ));
+      await tester.pump();
+      expect(find.text('UBICACIÓN APAGADA'), findsOneWidget);
+      expect(find.text('Activa Servicios de Localización'), findsOneWidget);
+      expect(find.text('Ajustes'), findsOneWidget);
+    });
+
+    testWidgets('(g) LocationUnavailable → no renderiza (oculto silente)',
+        (tester) async {
+      final cubit = _FakeLocationCubit(LocationUnavailable());
+      await tester.pumpWidget(_wrap(
+        const LocationPromptBanner(),
+        cubit.state,
+        cubit,
+      ));
+      await tester.pump();
+      expect(_bySemId('home-location-prompt'), findsNothing);
+    });
+  });
+}

--- a/test/ui/components/open_now_callout_test.dart
+++ b/test/ui/components/open_now_callout_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:guachinches/config/app_theme.dart';
+import 'package:guachinches/ui/components/open_now_callout.dart';
+
+Finder _bySemId(String id) => find.byWidgetPredicate(
+      (w) => w is Semantics && w.properties.identifier == id,
+    );
+
+Widget _wrap(Widget child) => MaterialApp(
+      theme: appLightTheme,
+      darkTheme: appDarkTheme,
+      home: Scaffold(body: SizedBox(width: 400, child: child)),
+    );
+
+void main() {
+  group('OpenNowCallout', () {
+    testWidgets('(a) count=23 muestra plural "23 sitios abiertos cerca"',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(const OpenNowCallout(count: 23, contextLabel: 'Tenerife')),
+      );
+      await tester.pump();
+
+      expect(_bySemId('home-cerca-ahora-cta'), findsOneWidget);
+      expect(find.text('23 sitios abiertos cerca'), findsOneWidget);
+      expect(find.text('ABIERTOS AHORA · TENERIFE'), findsOneWidget);
+      // No debe aparecer copy del estado vacío
+      expect(find.text('Sin abiertos cerca'), findsNothing);
+    });
+
+    testWidgets('(b) count=1 muestra singular "1 sitio abierto cerca"',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(const OpenNowCallout(count: 1, contextLabel: 'La Gomera')),
+      );
+      await tester.pump();
+      expect(find.text('1 sitio abierto cerca'), findsOneWidget);
+      expect(find.text('ABIERTOS AHORA · LA GOMERA'), findsOneWidget);
+    });
+
+    testWidgets('(c) count=0 muestra estado vacío con tono "abre pronto"',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(const OpenNowCallout(count: 0, contextLabel: 'El Hierro')),
+      );
+      await tester.pump();
+      expect(find.text('Sin abiertos cerca'), findsOneWidget);
+      expect(find.text('ABRE PRONTO · EL HIERRO'), findsOneWidget);
+      // Cuando count=0 no hay LIVE dot (eyebrow sin punto verde)
+      expect(find.text('ABIERTOS AHORA · EL HIERRO'), findsNothing);
+    });
+
+    testWidgets('(d) count>99 colapsa a copy "Muchos abiertos cerca"',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(const OpenNowCallout(count: 124, contextLabel: 'Tenerife')),
+      );
+      await tester.pump();
+      expect(find.text('Muchos abiertos cerca'), findsOneWidget);
+      expect(find.text('124 sitios abiertos cerca'), findsNothing);
+    });
+
+    testWidgets('(e) tap invoca onTap', (tester) async {
+      var tapped = 0;
+      await tester.pumpWidget(
+        _wrap(OpenNowCallout(
+          count: 5,
+          contextLabel: 'Tenerife',
+          onTap: () => tapped++,
+        )),
+      );
+      await tester.pump();
+      await tester.tap(_bySemId('home-cerca-ahora-cta'));
+      expect(tapped, 1);
+    });
+
+    testWidgets('(f) sin onTap el callout no tiene chevron de acción',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(const OpenNowCallout(count: 5, contextLabel: 'Tenerife')),
+      );
+      await tester.pump();
+      expect(find.byIcon(Icons.arrow_forward_rounded), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
…contextual

Rediseño del callout "Abiertos AHORA" con LIVE dot pulsante, número real de sitios y banda lateral verde laurisilva (en lugar del card amarillo opaco con texto blanco que rompía contraste).

Banner global de ubicación adaptativo según sub-estado:
- LocationDenied → dispara modal nativo iOS (requestPermission).
- LocationPermanentlyDenied → push LocationDeniedScreen con guía.
- LocationServiceDisabled → push LocationDeniedScreen con instrucciones para activar Servicios de Localización. LocationCubit emite los 3 sub-tipos (jerarquía retrocompatible: todos siguen siendo `is LocationDenied`). Helper `handleLocationPromptTap` centraliza la decisión y la usan banner + CercaAhoraScreen.

Sección "HOY EN ..." envuelta en ContextualSectionCard (fondo cremaSoft + banda lateral cálida + borde redondeado + sombra suave) para que banner y carrusel se lean como una unidad. CardHorizontal NO se toca.

Fix splash colgado: getVersion() timeout 6s, try/catch defensivo en el presenter (si falla → continúa con versionBD "1.0.0" → home), watchdog de 12s en SplashScreen que fuerza mainFunction si la navegación no ocurrió. Mitiga backend caído en :459 sin bloquear el arranque.

Fix CercaAhoraScreen: distinguir Initial/Loading (spinner) de Denied (empty state). En initState dispara requestLocation si state es Initial — antes podía quedar en "Necesitamos tu ubicación" aunque hubiera permisos concedidos.

Tests: 13 nuevos (open_now_callout 6 + location_prompt_banner 7).